### PR TITLE
Add Security response tests

### DIFF
--- a/src/main/java/org/opensearch/security/filter/SecurityResponse.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityResponse.java
@@ -77,10 +77,8 @@ public class SecurityResponse {
         List<String> header = headers.get(name);
         if (header == null) {
             header = new ArrayList<>();
-            System.out.println("Adding attribute header of " + value);
             headers.put(name, header);
         }
-        System.out.println("Adding header of " + value);
         header.add(value);
     }
 

--- a/src/main/java/org/opensearch/security/filter/SecurityResponse.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityResponse.java
@@ -77,8 +77,10 @@ public class SecurityResponse {
         List<String> header = headers.get(name);
         if (header == null) {
             header = new ArrayList<>();
+            System.out.println("Adding attribute header of " + value);
             headers.put(name, header);
         }
+        System.out.println("Adding header of " + value);
         header.add(value);
     }
 

--- a/src/test/java/org/opensearch/security/filter/SecurityResponseTests.java
+++ b/src/test/java/org/opensearch/security/filter/SecurityResponseTests.java
@@ -11,7 +11,11 @@
 
 package org.opensearch.security.filter;
 
+import java.util.List;
+import java.util.Map;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.http.HttpStatus;
+import org.apache.http.protocol.HTTP;
 import org.junit.Test;
 
 import org.opensearch.common.xcontent.XContentType;
@@ -23,12 +27,124 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class SecurityResponseTests {
 
+
+    /**
+     * This test should check whether a basic constructor with the JSON content type is successfully converted to RestResponse
+     */
     @Test
     public void testSecurityResponseHasSingleContentType() {
         final SecurityResponse response = new SecurityResponse(HttpStatus.SC_OK, null, "foo bar", XContentType.JSON.mediaType());
-
         final RestResponse restResponse = response.asRestResponse();
         assertThat(restResponse.status(), equalTo(RestStatus.OK));
         assertThat(restResponse.contentType(), equalTo(XContentType.JSON.mediaType()));
+    }
+
+    /**
+     * This test should check whether adding a new HTTP Header for the content type takes the argument or the added header (should take arg.)
+     */
+    @Test
+    public void testSecurityResponseMultipleContentTypesUsesPassed() {
+        final SecurityResponse response = new SecurityResponse(HttpStatus.SC_OK, null, "foo bar", XContentType.JSON.mediaType());
+        response.addHeader(HttpHeaders.CONTENT_TYPE, "plain/text");
+        assertThat(response.getHeaders().get("Content-Type"), equalTo(List.of("plain/text")));
+        final RestResponse restResponse = response.asRestResponse();
+        assertThat(restResponse.contentType(), equalTo(XContentType.JSON.mediaType()));
+        assertThat(restResponse.status(), equalTo(RestStatus.OK));
+    }
+
+    /**
+     * This test should check whether specifying no content type correctly uses JSON
+     */
+    @Test
+    public void testSecurityResponseDefaultContentTypeIsJson() {
+        final SecurityResponse response = new SecurityResponse(HttpStatus.SC_OK, null, "foo bar");
+        final RestResponse restResponse = response.asRestResponse();
+        assertThat(restResponse.contentType(), equalTo(XContentType.JSON.mediaType()));
+        assertThat(restResponse.status(), equalTo(RestStatus.OK)); // This fails because it is a text/plain but we should pick one default type and stick to it IMO
+    }
+
+    /**
+     * This test checks whether adding a new ContentType header actually changes the converted content type header  (it should not)
+     */
+    @Test
+    public void testSecurityResponseSetHeaderContentTypeDoesNothing() {
+        final SecurityResponse response = new SecurityResponse(HttpStatus.SC_OK, null, "foo bar");
+        response.addHeader(HttpHeaders.CONTENT_TYPE, XContentType.JSON.mediaType());
+        final RestResponse restResponse = response.asRestResponse();
+        assertThat(restResponse.contentType(), equalTo("text/plain; charset=UTF-8"));
+        assertThat(restResponse.status(), equalTo(RestStatus.OK));
+    }
+
+    /**
+     * This test should check whether adding a multiple new HTTP Headers for the content type takes the argument or the added header (should take arg.)
+     */
+    @Test
+    public void testSecurityResponseAddMultipleContentTypeHeaders() {
+        final SecurityResponse response = new SecurityResponse(HttpStatus.SC_OK, null, "foo bar", XContentType.JSON.mediaType());
+        response.addHeader(HttpHeaders.CONTENT_TYPE, "plain/text");
+        assertThat(response.getHeaders().get("Content-Type"), equalTo(List.of("plain/text")));
+        response.addHeader(HttpHeaders.CONTENT_TYPE, "newContentType");
+        assertThat(response.getHeaders().get("Content-Type"), equalTo(List.of("plain/text", "newContentType")));
+        final RestResponse restResponse = response.asRestResponse();
+        assertThat(restResponse.status(), equalTo(RestStatus.OK));
+    }
+
+    /**
+     * This test confirms that fake content types work for conversion
+     */
+    @Test
+    public void testSecurityResponseFakeContentTypeArgumentPasses() {
+        final SecurityResponse response = new SecurityResponse(HttpStatus.SC_OK, null, "foo bar", "testType");
+        final RestResponse restResponse = response.asRestResponse();
+        assertThat(restResponse.contentType(), equalTo("testType"));
+        assertThat(restResponse.status(), equalTo(RestStatus.OK));
+    }
+
+    /**
+     * This test checks that types passed as part of the Headers parameter in the argument do not overwrite actual Content Type
+     */
+    @Test
+    public void testSecurityResponseContentTypeInConstructorHeader() {
+        final SecurityResponse response = new SecurityResponse(HttpStatus.SC_OK, Map.of("Content-Type", "testType"), "foo bar");
+        assertThat(response.getHeaders().get("Content-Type"), equalTo(List.of("testType")));
+        final RestResponse restResponse = response.asRestResponse();
+        assertThat(restResponse.contentType(), equalTo(XContentType.JSON.mediaType()));
+        assertThat(restResponse.status(), equalTo(RestStatus.OK));
+    }
+
+    /**
+     * This test confirms the same as above but with a conflicting content type arg
+     */
+    @Test
+    public void testSecurityResponseContentTypeInConstructorHeaderConflicts() {
+        final SecurityResponse response = new SecurityResponse(HttpStatus.SC_OK, Map.of("Content-Type", "testType"), "foo bar", XContentType.JSON.mediaType());
+        assertThat(response.getHeaders().get("Content-Type"), equalTo(List.of("testType")));
+        final RestResponse restResponse = response.asRestResponse();
+        assertThat(restResponse.contentType(), equalTo(XContentType.JSON.mediaType()));
+        assertThat(restResponse.status(), equalTo(RestStatus.OK));
+    }
+
+    /**
+     * This test should check whether unauthorized requests are converted properly
+     */
+    @Test
+    public void testSecurityResponseUnauthorizedRequestWithPlainTextContentType(){
+        final SecurityResponse response = new SecurityResponse(HttpStatus.SC_UNAUTHORIZED, null, "foo bar");
+        response.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        final RestResponse restResponse = response.asRestResponse();
+        assertThat(restResponse.contentType(), equalTo("text/plain; charset=UTF-8"));
+        assertThat(restResponse.status(), equalTo(RestStatus.UNAUTHORIZED));
+    }
+
+    /**
+     * This test should check whether forbidden requests are converted properly
+     */
+    @Test
+    public void testSecurityResponseForbiddenRequestWithPlainTextContentType(){
+        final SecurityResponse response = new SecurityResponse(HttpStatus.SC_FORBIDDEN, null, "foo bar");
+        response.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        final RestResponse restResponse = response.asRestResponse();
+        assertThat(restResponse.contentType(), equalTo("text/plain; charset=UTF-8"));
+        assertThat(restResponse.status(), equalTo(RestStatus.FORBIDDEN));
     }
 }


### PR DESCRIPTION
### Description
This adds tests around the Security Response handling and its conversion to a RestResponse.

There is a known failing test I marked. I do not like that we don't pick a standard default type and would like us to do so. I would pick JSON and that is what I wrote the test for, but I can be overruled to use a different type or keep the behavior in the split way it is now.  

### Check List
- [x] New functionality includes testing
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
