### PR TITLE
Support multiple audiences when configuring `required_audience` for auth domains utilizing JWT 

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +141,15 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         final AuthCredentials ac = new AuthCredentials(subject, roles).markComplete();
 
         for (Entry<String, Object> claim : claimsSet.getClaims().entrySet()) {
-            ac.addAttribute("attr.jwt." + claim.getKey(), String.valueOf(claim.getValue()));
+            if (claim.getValue() instanceof Collection<?>) {
+                List<String> values = new ArrayList<>();
+                for (Object value : (Collection<?>) claim.getValue()) {
+                    values.add(String.valueOf(value));
+                }
+                ac.addAttribute("attr.jwt." + claim.getKey(), String.join(",", values));
+            } else {
+                ac.addAttribute("attr.jwt." + claim.getKey(), String.valueOf(claim.getValue()));
+            }
         }
 
         return ac;

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -16,6 +16,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.ParseException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -59,7 +60,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     private final String jwtUrlParameter;
     private final String subjectKey;
     private final String rolesKey;
-    private final String requiredAudience;
+    private final List<String> requiredAudience;
     private final String requiredIssuer;
 
     public static final int DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS = 30;
@@ -72,7 +73,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         rolesKey = settings.get("roles_key");
         subjectKey = settings.get("subject_key");
         clockSkewToleranceSeconds = settings.getAsInt("jwt_clock_skew_tolerance_seconds", DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS);
-        requiredAudience = settings.get("required_audience");
+        requiredAudience = settings.getAsList("required_audience");
         requiredIssuer = settings.get("required_issuer");
 
         try {
@@ -246,7 +247,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         );
     }
 
-    public String getRequiredAudience() {
+    public List<String> getRequiredAudience() {
         return requiredAudience;
     }
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -11,11 +11,9 @@
 
 package com.amazon.dlic.auth.http.jwt;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -31,26 +29,18 @@ import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.core.common.Strings;
 import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.filter.SecurityResponse;
 import org.opensearch.security.user.AuthCredentials;
+import org.opensearch.security.util.KeyUtils;
 
-import com.amazon.dlic.auth.http.jwt.keybyoidc.AuthenticatorUnavailableException;
-import com.amazon.dlic.auth.http.jwt.keybyoidc.BadCredentialsException;
-import com.amazon.dlic.auth.http.jwt.keybyoidc.JwtVerifier;
-import com.amazon.dlic.auth.http.jwt.keybyoidc.KeyProvider;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.KeyUse;
-import com.nimbusds.jose.jwk.OctetSequenceKey;
-import com.nimbusds.jwt.JWTClaimsSet;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.JwtParserBuilder;
 import io.jsonwebtoken.security.WeakKeyException;
 
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
-import static org.opensearch.security.authtoken.jwt.KeyPaddingUtil.padSecret;
-import static com.amazon.dlic.auth.http.jwt.AbstractHTTPJwtAuthenticator.DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS;
 
 public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
@@ -59,17 +49,14 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     private static final Pattern BASIC = Pattern.compile("^\\s*Basic\\s.*", Pattern.CASE_INSENSITIVE);
     private static final String BEARER = "bearer ";
 
-    private KeyProvider keyProvider;
-    private JwtVerifier jwtVerifier;
+    private final JwtParser jwtParser;
     private final String jwtHeaderName;
     private final boolean isDefaultAuthHeader;
     private final String jwtUrlParameter;
     private final String rolesKey;
     private final String subjectKey;
-    private final List<String> requiredAudience;
-    private final String requiredIssuer;
-
-    private final int clockSkewToleranceSeconds;
+    private final List<String> requireAudience;
+    private final String requireIssuer;
 
     public HTTPJwtAuthenticator(final Settings settings, final Path configPath) {
         super();
@@ -80,46 +67,29 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         isDefaultAuthHeader = AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
         rolesKey = settings.get("roles_key");
         subjectKey = settings.get("subject_key");
-        clockSkewToleranceSeconds = settings.getAsInt("jwt_clock_skew_tolerance_seconds", DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS);
-        requiredAudience = settings.getAsList("required_audience");
-        requiredIssuer = settings.get("required_issuer");
+        requireAudience = settings.getAsList("required_audience");
+        requireIssuer = settings.get("required_issuer");
 
-        try {
-            this.keyProvider = this.initKeyProvider(settings, configPath);
-            jwtVerifier = new JwtVerifier(keyProvider, clockSkewToleranceSeconds, requiredIssuer, requiredAudience);
-
-        } catch (Exception e) {
-            log.error("Error creating JWT authenticator. JWT authentication will not work", e);
-            throw new RuntimeException(e);
-        }
-    }
-
-    private KeyProvider initKeyProvider(Settings settings, Path configPath) throws Exception {
-        return new KeyProvider() {
-
-            @Override
-            public JWK getKeyAfterRefresh(String kid) throws AuthenticatorUnavailableException, BadCredentialsException {
-                return getSigningKey(settings);
+        final JwtParserBuilder jwtParserBuilder = KeyUtils.createJwtParserBuilderFromSigningKey(signingKey, log);
+        if (jwtParserBuilder == null) {
+            jwtParser = null;
+        } else {
+            if (requireAudience != null && !requireAudience.isEmpty()) {
+                for (String aud : requireAudience) {
+                    jwtParserBuilder.requireAudience(aud);
+                }
             }
 
-            @Override
-            public JWK getKey(String kid) throws AuthenticatorUnavailableException, BadCredentialsException {
-                return getSigningKey(settings);
+            if (requireIssuer != null) {
+                jwtParserBuilder.requireIssuer(requireIssuer);
             }
-        };
-    }
 
-    private JWK getSigningKey(Settings settings) {
-        String signingKey = settings.get("signing_key");
-
-        if (!Strings.isNullOrEmpty(signingKey)) {
-            signingKey = padSecret(new String(Base64.getUrlDecoder().decode(signingKey), StandardCharsets.UTF_8), JWSAlgorithm.HS512);
-
-            return new OctetSequenceKey.Builder(signingKey.getBytes(StandardCharsets.UTF_8)).algorithm(JWSAlgorithm.HS512)
-                .keyUse(KeyUse.SIGNATURE)
-                .build();
+            final SecurityManager sm = System.getSecurityManager();
+            if (sm != null) {
+                sm.checkPermission(new SpecialPermission());
+            }
+            jwtParser = AccessController.doPrivileged((PrivilegedAction<JwtParser>) jwtParserBuilder::build);
         }
-        return null;
     }
 
     @Override
@@ -143,7 +113,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     }
 
     private AuthCredentials extractCredentials0(final SecurityRequest request) {
-        if (jwtVerifier == null) {
+        if (jwtParser == null) {
             log.error("Missing Signing Key. JWT authentication will not work");
             return null;
         }
@@ -181,7 +151,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         }
 
         try {
-            final JWTClaimsSet claims = jwtVerifier.getVerifiedJwtToken(jwtToken).getJWTClaimsSet();
+            final Claims claims = jwtParser.parseClaimsJws(jwtToken).getBody();
 
             final String subject = extractSubject(claims, request);
 
@@ -194,7 +164,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
             final AuthCredentials ac = new AuthCredentials(subject, roles).markComplete();
 
-            for (Entry<String, Object> claim : claims.getClaims().entrySet()) {
+            for (Entry<String, Object> claim : claims.entrySet()) {
                 ac.addAttribute("attr.jwt." + claim.getKey(), String.valueOf(claim.getValue()));
             }
 
@@ -224,11 +194,11 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         return "jwt";
     }
 
-    protected String extractSubject(final JWTClaimsSet claims, final SecurityRequest request) {
+    protected String extractSubject(final Claims claims, final SecurityRequest request) {
         String subject = claims.getSubject();
         if (subjectKey != null) {
             // try to get roles from claims, first as Object to avoid having to catch the ExpectedTypeException
-            Object subjectObject = claims.getClaim(subjectKey);
+            Object subjectObject = claims.get(subjectKey, Object.class);
             if (subjectObject == null) {
                 log.warn("Failed to get subject from JWT claims, check if subject_key '{}' is correct.", subjectKey);
                 return null;
@@ -248,13 +218,13 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     }
 
     @SuppressWarnings("unchecked")
-    protected String[] extractRoles(final JWTClaimsSet claims, final SecurityRequest request) {
+    protected String[] extractRoles(final Claims claims, final SecurityRequest request) {
         // no roles key specified
         if (rolesKey == null) {
             return new String[0];
         }
         // try to get roles from claims, first as Object to avoid having to catch the ExpectedTypeException
-        final Object rolesObject = claims.getClaim(rolesKey);
+        final Object rolesObject = claims.get(rolesKey, Object.class);
         if (rolesObject == null) {
             log.warn(
                 "Failed to get roles from JWT claims with roles_key '{}'. Check if this key is correct and available in the JWT payload.",

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
@@ -134,7 +134,7 @@ public class JwtVerifier {
         List<String> audience = claims.getAudience();
         String issuer = claims.getIssuer();
 
-        if (requiredAudience.isEmpty() || !requiredAudience.containsAll(audience)) {
+        if (!requiredAudience.isEmpty() && !requiredAudience.containsAll(audience)) {
             throw new BadJWTException("Invalid audience");
         }
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
@@ -13,6 +13,9 @@ package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
 import java.text.ParseException;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -38,13 +41,13 @@ public class JwtVerifier {
     private final KeyProvider keyProvider;
     private final int clockSkewToleranceSeconds;
     private final String requiredIssuer;
-    private final String requiredAudience;
+    private final Set<String> requiredAudience;
 
-    public JwtVerifier(KeyProvider keyProvider, int clockSkewToleranceSeconds, String requiredIssuer, String requiredAudience) {
+    public JwtVerifier(KeyProvider keyProvider, int clockSkewToleranceSeconds, String requiredIssuer, List<String> requiredAudience) {
         this.keyProvider = keyProvider;
         this.clockSkewToleranceSeconds = clockSkewToleranceSeconds;
         this.requiredIssuer = requiredIssuer;
-        this.requiredAudience = requiredAudience;
+        this.requiredAudience = new HashSet<>(requiredAudience);
     }
 
     public SignedJWT getVerifiedJwtToken(String encodedJwt) throws BadCredentialsException {
@@ -118,7 +121,8 @@ public class JwtVerifier {
             DefaultJWTClaimsVerifier<SimpleSecurityContext> claimsVerifier = new DefaultJWTClaimsVerifier<>(
                 requiredAudience,
                 null,
-                Collections.emptySet()
+                Collections.emptySet(),
+                null
             );
             claimsVerifier.setMaxClockSkew(clockSkewToleranceSeconds);
             claimsVerifier.verify(claims, null);
@@ -127,10 +131,10 @@ public class JwtVerifier {
     }
 
     private void validateRequiredAudienceAndIssuer(JWTClaimsSet claims) throws BadJWTException {
-        String audience = claims.getAudience().stream().findFirst().orElse("");
+        List<String> audience = claims.getAudience();
         String issuer = claims.getIssuer();
 
-        if (!Strings.isNullOrEmpty(requiredAudience) && !requiredAudience.equals(audience)) {
+        if (requiredAudience.isEmpty() || !requiredAudience.containsAll(audience)) {
             throw new BadJWTException("Invalid audience");
         }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -518,6 +518,7 @@ public class HTTPJwtAuthenticatorTest {
 
         Assert.assertNotNull(credentials);
         Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        Assert.assertEquals("test_audience1,test_audience2", credentials.getAttributes().get("attr.jwt.aud"));
     }
 
     @Test
@@ -573,10 +574,8 @@ public class HTTPJwtAuthenticatorTest {
     private AuthCredentials extractCredentialsFromJwtHeader(final Settings.Builder settingsBuilder, final JwtBuilder jwtBuilder) {
         final Settings settings = settingsBuilder.build();
         final String jwsToken = jwtBuilder.signWith(secretKey, SignatureAlgorithm.HS512).compact();
-        System.out.println("jwsToken: " + jwsToken);
         final HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         final Map<String, String> headers = Map.of("Authorization", jwsToken);
-        System.out.println("Calling on extractCredentials");
         return jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<>()).asSecurityRequest(), null);
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -483,6 +483,70 @@ public class HTTPJwtAuthenticatorTest {
     }
 
     @Test
+    public void testRequiredAudienceWithMultipleAcceptableAudiencesAndCorrectAudience() {
+
+        final AuthCredentials credentials1 = extractCredentialsFromJwtHeader(
+            Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+                .putList("required_audience", "test_audience1", "test_audience2"),
+            Jwts.builder().subject("Leonard McCoy").audience().add("test_audience1").and()
+        );
+
+        Assert.assertNotNull(credentials1);
+        Assert.assertEquals("Leonard McCoy", credentials1.getUsername());
+
+        final AuthCredentials credentials2 = extractCredentialsFromJwtHeader(
+            Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+                .putList("required_audience", "test_audience1", "test_audience2"),
+            Jwts.builder().subject("Leonard McCoy").audience().add("test_audience2").and()
+        );
+
+        Assert.assertNotNull(credentials2);
+        Assert.assertEquals("Leonard McCoy", credentials2.getUsername());
+    }
+
+    @Test
+    public void testRequiredAudienceWithMultipleAcceptableAudiencesAndCorrectAudiences() {
+
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+            Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+                .putList("required_audience", "test_audience1", "test_audience2"),
+            Jwts.builder().subject("Leonard McCoy").audience().add("test_audience1").add("test_audience2").and()
+        );
+
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+    }
+
+    @Test
+    public void testRequiredAudienceWithMultipleAcceptableAudiencesAndIncorrectAudiences() {
+        // This JWT has one correct audience and one incorrect audience
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+            Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+                .putList("required_audience", "test_audience1", "test_audience2"),
+            Jwts.builder().subject("Leonard McCoy").audience().add("test_audience1").add("wrong_audience").and()
+        );
+
+        Assert.assertNull(credentials);
+    }
+
+    @Test
+    public void testRequiredAudienceWithMultipleAcceptableAudiencesAndIncorrectAudience() {
+
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+            Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+                .putList("required_audience", "test_audience1", "test_audience2"),
+            Jwts.builder().subject("Leonard McCoy").audience().add("wrong_audience").and()
+        );
+
+        Assert.assertNull(credentials);
+    }
+
+    @Test
     public void testRequiredIssuerWithCorrectAudience() {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
@@ -509,8 +573,10 @@ public class HTTPJwtAuthenticatorTest {
     private AuthCredentials extractCredentialsFromJwtHeader(final Settings.Builder settingsBuilder, final JwtBuilder jwtBuilder) {
         final Settings settings = settingsBuilder.build();
         final String jwsToken = jwtBuilder.signWith(secretKey, SignatureAlgorithm.HS512).compact();
+        System.out.println("jwsToken: " + jwsToken);
         final HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         final Map<String, String> headers = Map.of("Authorization", jwsToken);
+        System.out.println("Calling on extractCredentials");
         return jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<>()).asSecurityRequest(), null);
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -11,7 +11,6 @@
 package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
 import java.util.HashMap;
-import java.util.List;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.AfterClass;
@@ -59,7 +58,30 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(0, creds.getBackendRoles().size());
+        Assert.assertEquals(4, creds.getAttributes().size());
+    }
+
+    @Test
+    public void basicTestWithMultipleAudiences() {
+        Settings settings = Settings.builder()
+            .put("openid_connect_url", mockIdpServer.getDiscoverUri())
+            .put("required_issuer", TestJwts.TEST_ISSUER)
+            .putList("required_audience", TestJwts.TEST_AUDIENCE, TestJwts.TEST_AUDIENCE2)
+            .build();
+
+        HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+        AuthCredentials creds = jwtAuth.extractCredentials(
+            new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_MULTIPLE_AUDIENCES_OCT_1), new HashMap<>())
+                .asSecurityRequest(),
+            null
+        );
+
+        Assert.assertNotNull(creds);
+        Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
+        Assert.assertEquals(TestJwts.TEST_AUDIENCE + "," + TestJwts.TEST_AUDIENCE2, creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
@@ -81,7 +103,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
@@ -154,6 +176,24 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
     }
 
     @Test
+    public void jwksNotMatchingRequiredAudiencesInClaimTest() {
+        Settings settings = Settings.builder()
+            .put("jwks_uri", mockIdpServer.getJwksUri())
+            .putList("required_audience", TestJwts.TEST_AUDIENCE, "Wrong Audience")
+            .build();
+
+        HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+        AuthCredentials creds = jwtAuth.extractCredentials(
+            new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_MULTIPLE_AUDIENCES_OCT_1), new HashMap<>())
+                .asSecurityRequest(),
+            null
+        );
+
+        Assert.assertNull(creds);
+    }
+
+    @Test
     public void jwksUriMissingTest() {
         var exception = Assert.assertThrows(Exception.class, () -> {
             HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(Settings.builder().build(), null);
@@ -187,7 +227,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
@@ -210,7 +250,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
@@ -345,7 +385,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
@@ -383,7 +423,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
@@ -11,6 +11,7 @@
 
 package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
@@ -35,18 +36,23 @@ class TestJwts {
 
     static final String TEST_AUDIENCE = "TestAudience";
 
+    static final String TEST_AUDIENCE2 = "TestAudience2";
+
     static final String MCCOY_SUBJECT = "Leonard McCoy";
 
     static final String TEST_ISSUER = "TestIssuer";
 
     static final JWTClaimsSet MC_COY = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
-
     static final JWTClaimsSet MC_COY_2 = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
-
-    static final JWTClaimsSet MC_COY_NO_AUDIENCE = create(MCCOY_SUBJECT, null, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
-
+    static final JWTClaimsSet MC_COY_NO_AUDIENCE = create(MCCOY_SUBJECT, List.of(), TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
+    static final JWTClaimsSet MC_COY_MULTIPLE_AUDIENCES = create(
+        MCCOY_SUBJECT,
+        List.of(TEST_AUDIENCE, TEST_AUDIENCE2),
+        TEST_ISSUER,
+        ROLES_CLAIM,
+        TEST_ROLES_STRING
+    );
     static final JWTClaimsSet MC_COY_NO_ISSUER = create(MCCOY_SUBJECT, TEST_AUDIENCE, null, ROLES_CLAIM, TEST_ROLES_STRING);
-
     static final JWTClaimsSet MC_COY_EXPIRED = create(
         MCCOY_SUBJECT,
         TEST_AUDIENCE,
@@ -63,6 +69,7 @@ class TestJwts {
 
     static final String MC_COY_SIGNED_NO_AUDIENCE_OCT_1 = createSigned(MC_COY_NO_AUDIENCE, TestJwk.OCT_1);
     static final String MC_COY_SIGNED_NO_ISSUER_OCT_1 = createSigned(MC_COY_NO_ISSUER, TestJwk.OCT_1);
+    static final String MC_COY_SIGNED_MULTIPLE_AUDIENCES_OCT_1 = createSigned(MC_COY_MULTIPLE_AUDIENCES, TestJwk.OCT_1);
 
     static final String MC_COY_SIGNED_OCT_1_INVALID_KID = createSigned(MC_COY, TestJwk.FORWARD_SLASH_KID_OCT_1);
 
@@ -88,6 +95,27 @@ class TestJwts {
         claimsBuilder.subject(subject);
         if (audience != null) {
             claimsBuilder.audience(audience);
+        }
+        if (issuer != null) {
+            claimsBuilder.issuer(issuer);
+        }
+
+        if (moreClaims != null) {
+            for (int i = 0; i < moreClaims.length; i += 2) {
+                claimsBuilder.claim(String.valueOf(moreClaims[i]), moreClaims[i + 1]);
+            }
+        }
+
+        // JwtToken result = new JwtToken(claimsBuilder);
+        return claimsBuilder.build();
+    }
+
+    static JWTClaimsSet create(String subject, List<String> audiences, String issuer, Object... moreClaims) {
+        JWTClaimsSet.Builder claimsBuilder = new JWTClaimsSet.Builder();
+
+        claimsBuilder.subject(subject);
+        if (audiences != null && !audiences.isEmpty()) {
+            claimsBuilder.audience(audiences);
         }
         if (issuer != null) {
             claimsBuilder.issuer(issuer);


### PR DESCRIPTION
### Description

Opening this in Draft to solicit feedback. This allows configuring JWT, SAML and OIDC backends with a list of required audiences or a single required audience. 

The [RFC for JWTs](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3) does not specify how multiple audiences should be handled and instead mentions:

> The interpretation of audience values is generally application specific.

This PR allows configuration of an auth backend with multiple required audiences and when authenticating a token, the token's `aud` claim must be a subset of the configured required audiences. If a token's `aud` claim has at least one audience that is not in the list of required audiences for the auth domain then it would fail authentication.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Issues Resolved

https://github.com/opensearch-project/security/pull/3765

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
