### PR TITLE
Only allow TransportConfigUpdateAction after node has been set as bootstrapped

### DIFF
--- a/src/main/java/org/opensearch/security/action/configupdate/TransportConfigUpdateAction.java
+++ b/src/main/java/org/opensearch/security/action/configupdate/TransportConfigUpdateAction.java
@@ -125,8 +125,10 @@ public class TransportConfigUpdateAction extends TransportNodesAction<
 
     @Override
     protected ConfigUpdateNodeResponse nodeOperation(final NodeConfigUpdateRequest request) {
-        configurationRepository.reloadConfiguration(CType.fromStringValues((request.request.getConfigTypes())));
-        backendRegistry.get().invalidateCache();
+        if (dynamicConfigFactory.isBootstrapped()) {
+            configurationRepository.reloadConfiguration(CType.fromStringValues((request.request.getConfigTypes())));
+            backendRegistry.get().invalidateCache();
+        }
         return new ConfigUpdateNodeResponse(clusterService.localNode(), request.request.getConfigTypes(), null);
     }
 

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -219,9 +219,11 @@ public class ConfigurationRepository {
                     try {
                         LOGGER.debug("Try to load config ...");
                         reloadConfiguration(Arrays.asList(CType.values()));
+                        dynamicConfigFactory.setBootstrapped();
                         break;
                     } catch (Exception e) {
                         LOGGER.debug("Unable to load configuration due to {}", String.valueOf(ExceptionUtils.getRootCause(e)));
+                        dynamicConfigFactory.setBootstrapped();
                         try {
                             Thread.sleep(3000);
                         } catch (InterruptedException e1) {
@@ -323,6 +325,7 @@ public class ConfigurationRepository {
                     "Will not attempt to create index {} and default configs if they are absent. Will not perform background initialization",
                     securityIndex
                 );
+                dynamicConfigFactory.setBootstrapped();
             }
         } catch (Throwable e2) {
             LOGGER.error("Error during node initialization: {}", e2, e2);

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -125,6 +125,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     protected final Logger log = LogManager.getLogger(this.getClass());
     private final ConfigurationRepository cr;
     private final AtomicBoolean initialized = new AtomicBoolean();
+    private final AtomicBoolean bootstrapped = new AtomicBoolean();
     private final EventBus eventBus = EVENT_BUS_BUILDER.logger(new JavaLogger(DynamicConfigFactory.class.getCanonicalName())).build();
     private final Settings opensearchSettings;
     private final Path configPath;
@@ -315,7 +316,6 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         }
 
         initialized.set(true);
-
     }
 
     private static ConfigV6 getConfigV6(SecurityDynamicConfiguration<?> sdc) {
@@ -333,6 +333,14 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     @Override
     public final boolean isInitialized() {
         return initialized.get();
+    }
+
+    public final boolean isBootstrapped() {
+        return bootstrapped.get();
+    }
+
+    public final void setBootstrapped() {
+        bootstrapped.set(true);
     }
 
     public void registerDCFListener(Object listener) {


### PR DESCRIPTION
Introduces another variable on DynamicConfigFactory called `bootstrapped` that behaves differently than the `initialized` variable. `bootstrapped` is a flag that signals to TransportConfigUpdateAction that it can start accepting updates.

There are 2 ways the security index can be created from scratch:

1. If `plugins.security.allow_default_init_securityindex` is set to **true** it will create the security index and load all yaml files
2. If `plugins.security.allow_default_init_securityindex` is set to **false**, the security index is not created on bootstrap and requires a user to run securityadmin to initialize security. When securityadmin is utilized, the cluster does depend on [TransportConfigUpdateAction](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/tools/SecurityAdmin.java#L975-L977) to initialize security so there still needs to be an avenue where this can update the config before `initialized` is set to **true**

This PR sets `bootstrapped` to **false** on node startup and explicitly sets it to **true** once its ok for TransportConfigUpdateAction to start accepting transport actions. In case 2) up above, it can be set to **true** before DynamicConfigFactory is `initialized` so that it can accept requests from securityadmin.