### PR TITLE
Alternative solution for tracking unconsumed parameters

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -130,10 +130,10 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         }
 
         if ((jwtToken == null || jwtToken.isEmpty()) && jwtUrlParameter != null) {
-            jwtToken = request.param(jwtUrlParameter);
+            jwtToken = request.params().get(jwtUrlParameter);
         } else {
             // just consume to avoid "contains unrecognized parameter"
-            request.param(jwtUrlParameter);
+            request.params().get(jwtUrlParameter);
         }
 
         if (jwtToken == null || jwtToken.length() == 0) {

--- a/src/main/java/org/opensearch/security/filter/NettyRequest.java
+++ b/src/main/java/org/opensearch/security/filter/NettyRequest.java
@@ -20,19 +20,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
-
 import javax.net.ssl.SSLEngine;
-
-import org.apache.commons.lang3.concurrent.ConcurrentException;
-import org.apache.commons.lang3.concurrent.LazyInitializer;
-import org.opensearch.http.netty4.Netty4HttpChannel;
-import org.opensearch.rest.RestRequest.Method;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 
+import org.opensearch.http.netty4.Netty4HttpChannel;
+import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.rest.RestUtils;
 
 import io.netty.handler.codec.http.HttpRequest;
@@ -130,7 +124,7 @@ public class NettyRequest implements SecurityRequest {
         public String get(final Object key) {
             // Never noticed this about java's map interface the getter is not generic
             if (key instanceof String) {
-                accessedKeys.add((String)key);
+                accessedKeys.add((String) key);
             }
             return super.get(key);
         }

--- a/src/main/java/org/opensearch/security/filter/OpenSearchRequest.java
+++ b/src/main/java/org/opensearch/security/filter/OpenSearchRequest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import javax.net.ssl.SSLEngine;
 
 import org.opensearch.rest.RestRequest;
@@ -85,7 +84,6 @@ public class OpenSearchRequest implements SecurityRequest {
         // params() Map consumes explict parameter access
         return Set.of();
     }
-
 
     /** Gets access to the underlying request object */
     public RestRequest breakEncapsulationForRequest() {

--- a/src/main/java/org/opensearch/security/filter/OpenSearchRequest.java
+++ b/src/main/java/org/opensearch/security/filter/OpenSearchRequest.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
 import javax.net.ssl.SSLEngine;
 
 import org.opensearch.rest.RestRequest;
@@ -79,9 +81,11 @@ public class OpenSearchRequest implements SecurityRequest {
     }
 
     @Override
-    public String param(String key) {
-        return underlyingRequest.param(key);
+    public Set<String> getUnconsumedParams() {
+        // params() Map consumes explict parameter access
+        return Set.of();
     }
+
 
     /** Gets access to the underlying request object */
     public RestRequest breakEncapsulationForRequest() {

--- a/src/main/java/org/opensearch/security/filter/SecurityRequest.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRequest.java
@@ -15,6 +15,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLEngine;
 
@@ -50,6 +51,6 @@ public interface SecurityRequest {
     /** The parameters associated with this request */
     Map<String, String> params();
 
-    /** Gets the parameter for the given key */
-    String param(String key);
+    /** The list of parameters that have been accessed but not recorded as being consumed */
+    Set<String> getUnconsumedParams();
 }

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -69,10 +69,10 @@ import org.greenrobot.eventbus.Subscribe;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.LEGACY_OPENDISTRO_PREFIX;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
-import static org.opensearch.security.http.SecurityHttpServerTransport.UNCONSUMED_PARAMS;
 import static org.opensearch.security.http.SecurityHttpServerTransport.CONTEXT_TO_RESTORE;
 import static org.opensearch.security.http.SecurityHttpServerTransport.EARLY_RESPONSE;
 import static org.opensearch.security.http.SecurityHttpServerTransport.IS_AUTHENTICATED;
+import static org.opensearch.security.http.SecurityHttpServerTransport.UNCONSUMED_PARAMS;
 
 public class SecurityRestFilter {
 

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -69,7 +69,7 @@ import org.greenrobot.eventbus.Subscribe;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.LEGACY_OPENDISTRO_PREFIX;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
-import static org.opensearch.security.http.SecurityHttpServerTransport.CONSUMED_PARAMS;
+import static org.opensearch.security.http.SecurityHttpServerTransport.UNCONSUMED_PARAMS;
 import static org.opensearch.security.http.SecurityHttpServerTransport.CONTEXT_TO_RESTORE;
 import static org.opensearch.security.http.SecurityHttpServerTransport.EARLY_RESPONSE;
 import static org.opensearch.security.http.SecurityHttpServerTransport.IS_AUTHENTICATED;
@@ -145,10 +145,10 @@ public class SecurityRestFilter {
                 }
             });
 
-            NettyAttribute.popFrom(request, CONSUMED_PARAMS).ifPresent(consumedParams -> {
-                for (String param : consumedParams) {
+            NettyAttribute.popFrom(request, UNCONSUMED_PARAMS).ifPresent(unconsumedParams -> {
+                for (String unconsumedParam : unconsumedParams) {
                     // Consume the parameter on the RestRequest
-                    request.param(param);
+                    request.param(unconsumedParam);
                 }
             });
 

--- a/src/main/java/org/opensearch/security/http/SecurityHttpServerTransport.java
+++ b/src/main/java/org/opensearch/security/http/SecurityHttpServerTransport.java
@@ -49,7 +49,7 @@ import io.netty.util.AttributeKey;
 public class SecurityHttpServerTransport extends SecuritySSLNettyHttpServerTransport {
 
     public static final AttributeKey<SecurityResponse> EARLY_RESPONSE = AttributeKey.newInstance("opensearch-http-early-response");
-    public static final AttributeKey<Set<String>> CONSUMED_PARAMS = AttributeKey.newInstance("opensearch-http-request-consumed-params");
+    public static final AttributeKey<Set<String>> UNCONSUMED_PARAMS = AttributeKey.newInstance("opensearch-http-request-consumed-params");
     public static final AttributeKey<ThreadContext.StoredContext> CONTEXT_TO_RESTORE = AttributeKey.newInstance(
         "opensearch-http-request-thread-context"
     );

--- a/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
+++ b/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
@@ -14,7 +14,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.http.netty4.Netty4HttpChannel;
 import org.opensearch.http.netty4.Netty4HttpServerTransport;
-import org.opensearch.security.filter.NettyRequest;
 import org.opensearch.security.filter.SecurityRequestChannel;
 import org.opensearch.security.filter.SecurityRequestChannelUnsupported;
 import org.opensearch.security.filter.SecurityRequestFactory;
@@ -33,11 +32,11 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.util.ReferenceCountUtil;
 
-import static org.opensearch.security.http.SecurityHttpServerTransport.UNCONSUMED_PARAMS;
 import static org.opensearch.security.http.SecurityHttpServerTransport.CONTEXT_TO_RESTORE;
 import static org.opensearch.security.http.SecurityHttpServerTransport.EARLY_RESPONSE;
 import static org.opensearch.security.http.SecurityHttpServerTransport.IS_AUTHENTICATED;
 import static org.opensearch.security.http.SecurityHttpServerTransport.SHOULD_DECOMPRESS;
+import static org.opensearch.security.http.SecurityHttpServerTransport.UNCONSUMED_PARAMS;
 
 @Sharable
 public class Netty4HttpRequestHeaderVerifier extends SimpleChannelInboundHandler<DefaultHttpRequest> {

--- a/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
+++ b/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
@@ -33,7 +33,7 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.util.ReferenceCountUtil;
 
-import static org.opensearch.security.http.SecurityHttpServerTransport.CONSUMED_PARAMS;
+import static org.opensearch.security.http.SecurityHttpServerTransport.UNCONSUMED_PARAMS;
 import static org.opensearch.security.http.SecurityHttpServerTransport.CONTEXT_TO_RESTORE;
 import static org.opensearch.security.http.SecurityHttpServerTransport.EARLY_RESPONSE;
 import static org.opensearch.security.http.SecurityHttpServerTransport.IS_AUTHENTICATED;
@@ -86,9 +86,7 @@ public class Netty4HttpRequestHeaderVerifier extends SimpleChannelInboundHandler
             // If request channel is completed and a response is sent, then there was a failure during authentication
             restFilter.checkAndAuthenticateRequest(requestChannel);
 
-            if (requestChannel instanceof NettyRequest) {
-                ctx.channel().attr(CONSUMED_PARAMS).set(((NettyRequest) requestChannel).getConsumedParams());
-            }
+            ctx.channel().attr(UNCONSUMED_PARAMS).set(requestChannel.getUnconsumedParams());
 
             ThreadContext.StoredContext contextToRestore = threadPool.getThreadContext().newStoredContext(false);
             ctx.channel().attr(CONTEXT_TO_RESTORE).set(contextToRestore);


### PR DESCRIPTION
### Description
Alternative solution for tracking unconsumed parameters

### Testing
✅  `./gradlew integrationTest --tests org.opensearch.security.http.JwtAuthenticationWithUrlParamTests`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
