### PR TITLE
WIP on FLS and Field Masking optimization

### DIFF
--- a/src/test/java/org/opensearch/security/UtilTests.java
+++ b/src/test/java/org/opensearch/security/UtilTests.java
@@ -30,11 +30,13 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auth.BackendRegistry;
+import org.opensearch.security.configuration.DlsFlsValveImpl;
 import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.hasher.PasswordHasherFactory;
 import org.opensearch.security.support.ConfigConstants;
@@ -271,5 +273,83 @@ public class UtilTests {
             ),
             is(false)
         );
+    }
+
+    @Test
+    public void testSimpleSubMap() {
+        Map<String, Set<String>> map1 = Map.of("key1", Set.of("a", "b"), "key2", Set.of("c"));
+
+        Map<String, Set<String>> map2 = Map.of("key1", Set.of("a", "b", "c"), "key2", Set.of("c", "d"), "key3", Set.of("e"));
+
+        assertTrue(DlsFlsValveImpl.isSubMap(map1, map2));
+    }
+
+    @Test
+    public void testNotSubMap_ExtraKeyInMap1() {
+        Map<String, Set<String>> map1 = Map.of("key1", Set.of("a", "b"), "key2", Set.of("c"), "key3", Set.of("e"));
+
+        Map<String, Set<String>> map2 = Map.of("key1", Set.of("a", "b", "c"), "key2", Set.of("c", "d"));
+
+        assertFalse(DlsFlsValveImpl.isSubMap(map1, map2));
+    }
+
+    @Test
+    public void testNotSubMap_SubsetMismatch() {
+        Map<String, Set<String>> map1 = Map.of("key1", Set.of("a", "b"), "key2", Set.of("c"));
+
+        Map<String, Set<String>> map2 = Map.of("key1", Set.of("a"), "key2", Set.of("c", "d"));
+
+        assertFalse(DlsFlsValveImpl.isSubMap(map1, map2));
+    }
+
+    @Test
+    public void testIdenticalMaps() {
+        Map<String, Set<String>> map1 = Map.of("key1", Set.of("a", "b"), "key2", Set.of("c", "d"));
+
+        Map<String, Set<String>> map2 = Map.of("key1", Set.of("a", "b"), "key2", Set.of("c", "d"));
+
+        assertTrue(DlsFlsValveImpl.isSubMap(map1, map2));
+    }
+
+    @Test
+    public void testEmptyMap1() {
+        Map<String, Set<String>> map1 = Map.of();
+
+        Map<String, Set<String>> map2 = Map.of("key1", Set.of("a", "b"), "key2", Set.of("c", "d"));
+
+        assertTrue(DlsFlsValveImpl.isSubMap(map1, map2));
+    }
+
+    @Test
+    public void testEmptyMap2() {
+        Map<String, Set<String>> map1 = Map.of("key1", Set.of("a", "b"));
+
+        Map<String, Set<String>> map2 = Map.of();
+
+        assertFalse(DlsFlsValveImpl.isSubMap(map1, map2));
+    }
+
+    @Test
+    public void testBothMapsEmpty() {
+        Map<String, Set<String>> map1 = Map.of();
+        Map<String, Set<String>> map2 = Map.of();
+
+        assertTrue(DlsFlsValveImpl.isSubMap(map1, map2));
+    }
+
+    @Test
+    public void testLargerSetsInMap2() {
+        Map<String, Set<String>> map1 = Map.of("key1", Set.of("a"), "key2", Set.of("c"));
+
+        Map<String, Set<String>> map2 = Map.of("key1", Set.of("a", "b", "c"), "key2", Set.of("c", "d", "e"));
+
+        assertTrue(DlsFlsValveImpl.isSubMap(map1, map2));
+    }
+
+    @Test
+    public void testEitherMapNull() {
+        assertFalse(DlsFlsValveImpl.isSubMap(null, Map.of()));
+        assertFalse(DlsFlsValveImpl.isSubMap(Map.of(), null));
+        assertFalse(DlsFlsValveImpl.isSubMap(null, null));
     }
 }


### PR DESCRIPTION
### Description

This PR revisits the data structure that carries the `<concrete index> -> Set<String> maskedFields` (or FLS) that is carried on the ThreadContext. Currently, the datastructure is carrying the entire `evaluatedDlsFlsConfig` which iterates through [all roles](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java#L305-L351) and computes a map of concrete indices matching the mattern on any role -> the set of masked Fields or Fls. 

An example data structure is like this:

```
{first-test-index=[lyrics::/(?<=.{1})./::*, artist::/(?<=.{1})./::*], second-test-index=[lyrics::/(?<=.{1})./::*]}
```

The problem with this is that if a request is only on a single index, this data structure will still contain all matched concrete indices -> set of maskedFields on the ThreadContext for every request.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
