### PR TITLE
Add ensureCustomSerialization to ensure that headers are serialized correctly with multiple transport hops

### DIFF
--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -69,4 +69,28 @@ public class Base64Helper {
         // If we see an exception now, we want the caller to see it -
         return Base64Helper.serializeObject(serializable, true);
     }
+
+    /**
+     * Ensures that the returned string is custom serialized.
+     *
+     * If the supplied string is a JDK serialized representation, will deserialize it and further serialize using
+     * custom, otherwise returns the string as is.
+     *
+     * @param string original string, can be JDK or custom serialized
+     * @return custom serialized string
+     */
+    public static String ensureCustomSerialized(final String string) {
+        Serializable serializable;
+        try {
+            serializable = Base64Helper.deserializeObject(string, true);
+        } catch (Exception e) {
+            // We received an exception when de-serializing the given string. It is probably custom serialized.
+            // Try to deserialize using custom
+            Base64Helper.deserializeObject(string, false);
+            // Since we could deserialize the object using custom, the string is already custom serialized, return as is
+            return string;
+        }
+        // If we see an exception now, we want the caller to see it -
+        return Base64Helper.serializeObject(serializable, false);
+    }
 }

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -231,13 +231,13 @@ public class SecurityInterceptor {
             }
 
             try {
-                if (serializationFormat == SerializationFormat.JDK) {
-                    Map<String, String> jdkSerializedHeaders = new HashMap<>();
+                if (serializationFormat == SerializationFormat.CustomSerializer_2_11) {
+                    Map<String, String> customSerializedHeaders = new HashMap<>();
                     HeaderHelper.getAllSerializedHeaderNames()
                         .stream()
                         .filter(k -> headerMap.get(k) != null)
-                        .forEach(k -> jdkSerializedHeaders.put(k, Base64Helper.ensureJDKSerialized(headerMap.get(k))));
-                    headerMap.putAll(jdkSerializedHeaders);
+                        .forEach(k -> customSerializedHeaders.put(k, Base64Helper.ensureCustomSerialized(headerMap.get(k))));
+                    headerMap.putAll(customSerializedHeaders);
                 }
                 getThreadContext().putHeader(headerMap);
             } catch (IllegalArgumentException iae) {

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -54,6 +54,15 @@ public class Base64HelperTest {
     }
 
     @Test
+    public void testEnsureCustomSerialized() {
+        String test = "string";
+        String jdkSerialized = Base64Helper.serializeObject(test, true);
+        String customSerialized = Base64Helper.serializeObject(test, false);
+        assertThat(Base64Helper.ensureCustomSerialized(jdkSerialized), is(customSerialized));
+        assertThat(Base64Helper.ensureCustomSerialized(customSerialized), is(customSerialized));
+    }
+
+    @Test
     public void testDuplicatedItemSizes() {
         var largeObject = new HashMap<String, Object>();
         var hm = new HashMap<>();


### PR DESCRIPTION
### Description

This PR fixes multiple issue:

- https://github.com/opensearch-project/security/issues/4494
- https://github.com/opensearch-project/security/issues/4670

When upgrading from 2.11/2.12/2.13 to >= 2.14, there can be an issue when deserializing threadContext headers on the receiving node due to the transmitting node re-using the serialization format from a previous transport hop.

This was particular seen in scenarios where there are a chain of transport hops, such as 2.14 (Coordinator node) -> 2.14 node -> 2.12 node

These scenarios can happen on ingestion during rolling upgrades where a replica shard may temporarily be on an older node than a primary shard.

This PR adds logic in the SecurityInterceptor to re-serialize the headers if they have previously been populated from a prior transport hop for backwards compatibility.

This PR also removes logic ensureJdkSerialization. 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

- https://github.com/opensearch-project/security/issues/4494
- https://github.com/opensearch-project/security/issues/4670

### Testing

Creating this PR in Draft until testing details are added.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
