### PR TITLE
Ensure that dual mode enabled flag from cluster settings can get propagated to core

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2166,7 +2166,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
     @Override
     public Optional<SecureSettingsFactory> getSecureSettingFactory(Settings settings) {
-        return Optional.of(new OpenSearchSecureSettingsFactory(threadPool, sks, evaluateSslExceptionHandler(), securityRestHandler));
+        return Optional.of(
+            new OpenSearchSecureSettingsFactory(threadPool, sks, evaluateSslExceptionHandler(), securityRestHandler, SSLConfig)
+        );
     }
 
     @SuppressWarnings("removal")

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
@@ -27,6 +27,7 @@ import org.opensearch.plugins.TransportExceptionHandler;
 import org.opensearch.security.filter.SecurityRestFilter;
 import org.opensearch.security.ssl.http.netty.Netty4ConditionalDecompressor;
 import org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier;
+import org.opensearch.security.ssl.transport.SSLConfig;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportAdapterProvider;
@@ -38,17 +39,20 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
     private final SecurityKeyStore sks;
     private final SslExceptionHandler sslExceptionHandler;
     private final SecurityRestFilter restFilter;
+    private final SSLConfig sslConfig;
 
     public OpenSearchSecureSettingsFactory(
         ThreadPool threadPool,
         SecurityKeyStore sks,
         SslExceptionHandler sslExceptionHandler,
-        SecurityRestFilter restFilter
+        SecurityRestFilter restFilter,
+        SSLConfig sslConfig
     ) {
         this.threadPool = threadPool;
         this.sks = sks;
         this.sslExceptionHandler = sslExceptionHandler;
         this.restFilter = restFilter;
+        this.sslConfig = sslConfig;
     }
 
     @Override
@@ -62,6 +66,11 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
                         sslExceptionHandler.logError(t, false);
                     }
                 });
+            }
+
+            @Override
+            public boolean isDualModeEnabled(Settings settings) {
+                return sslConfig.isDualModeEnabled();
             }
 
             @Override

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -674,7 +674,9 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
 
     @Override
     public Optional<SecureSettingsFactory> getSecureSettingFactory(Settings settings) {
-        return Optional.of(new OpenSearchSecureSettingsFactory(threadPool, sks, NOOP_SSL_EXCEPTION_HANDLER, securityRestHandler));
+        return Optional.of(
+            new OpenSearchSecureSettingsFactory(threadPool, sks, NOOP_SSL_EXCEPTION_HANDLER, securityRestHandler, SSLConfig)
+        );
     }
 
     protected Settings migrateSettings(Settings settings) {


### PR DESCRIPTION
### Description

Overrides a new method in the SecureTransportSettingsProvider interface to allow the security plugin to feed this value to core. This is required since the security plugin has a listener on cluster settings and allows this setting to be changed dynamically irrespective of the value in opensearch.yml

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
