### PR TITLE
Ensure body is logged when document is first created, otherwise log the diffs when log_request_body set to false for compliance config

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -639,17 +639,19 @@ public abstract class AbstractAuditLog implements AuditLog {
                         XContentType.JSON
                     )
                 ) {
-                    Object base64 = parser.map().values().iterator().next();
-                    if (base64 instanceof String) {
-                        msg.addSecurityConfigContentToRequestBody(
-                            new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8),
-                            id
-                        );
-                    } else {
-                        msg.addSecurityConfigTupleToRequestBody(
-                            new Tuple<XContentType, BytesReference>(XContentType.JSON, currentIndex.source()),
-                            id
-                        );
+                    if (auditConfigFilter.shouldLogRequestBody() || originalResult == null) {
+                        Object base64 = parser.map().values().iterator().next();
+                        if (base64 instanceof String) {
+                            msg.addSecurityConfigContentToRequestBody(
+                                new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8),
+                                id
+                            );
+                        } else {
+                            msg.addSecurityConfigTupleToRequestBody(
+                                new Tuple<XContentType, BytesReference>(XContentType.JSON, currentIndex.source()),
+                                id
+                            );
+                        }
                     }
                 } catch (Exception e) {
                     log.error(e.toString());

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -666,7 +666,9 @@ public abstract class AbstractAuditLog implements AuditLog {
                 // originalResult.internalSourceRef()));
 
                 // current source, normally not null or empty
-                msg.addTupleToRequestBody(new Tuple<MediaType, BytesReference>(XContentType.JSON, currentIndex.source()));
+                if (auditConfigFilter.shouldLogRequestBody() || originalResult == null) {
+                    msg.addTupleToRequestBody(new Tuple<MediaType, BytesReference>(XContentType.JSON, currentIndex.source()));
+                }
             }
 
         }


### PR DESCRIPTION
### Description

This PR ensures that the value of `log_request_body` is honored for the compliance logging. When using the compliance config, this PR will ensure that the document's source is audit logged in the `audit_request_body` when a document is first created, but otherwise it will not. When `write_log_diffs` is enabled, you can trace the full history of changes to documents on the tracked indices by looking for all events on the target index.

By default, the security index gets events audit logged so Compliant logging is a good feature to use to trace changes to the security configuration.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Issues Resolved

https://github.com/opensearch-project/security/issues/4534

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
