### PR TITLE
Run ResourceFocusedTest with transport-nio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -737,6 +737,7 @@ dependencies {
     }
     integrationTestImplementation 'com.unboundid:unboundid-ldapsdk:4.0.14'
     integrationTestImplementation "org.opensearch.plugin:mapper-size:${opensearch_version}"
+    integrationTestImplementation "org.opensearch.plugin:transport-nio-client:${opensearch_version}"
     integrationTestImplementation "org.apache.httpcomponents:httpclient-cache:4.5.14"
     integrationTestImplementation "org.apache.httpcomponents:httpclient:4.5.14"
     integrationTestImplementation "org.apache.httpcomponents:fluent-hc:4.5.14"

--- a/src/integrationTest/java/org/opensearch/security/ResourceFocusedTests.java
+++ b/src/integrationTest/java/org/opensearch/security/ResourceFocusedTests.java
@@ -40,6 +40,7 @@ import org.opensearch.test.framework.TestSecurityConfig.User;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.transport.nio.NioTransportPlugin;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -73,6 +74,8 @@ public class ResourceFocusedTests {
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
         .authc(AUTHC_HTTPBASIC_INTERNAL)
         .users(ADMIN_USER, LIMITED_USER)
+        .nodeSettings(Map.of("http.type", "nio-http-transport-secure"))
+        .plugin(NioTransportPlugin.class)
         .anonymousAuth(false)
         .doNotFailOnForbidden(true)
         .build();


### PR DESCRIPTION
### Description

Run the targeted test with `./gradlew integrationTest --tests ResourceFocusedTests`

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
