### PR TITLE
Implement new extension points in IdentityPlugin and add ContextProvidingPluginSubject

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/plugin/IndexDocumentIntoSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/IndexDocumentIntoSystemIndexAction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import org.opensearch.action.ActionType;
+
+public class IndexDocumentIntoSystemIndexAction extends ActionType<IndexDocumentIntoSystemIndexResponse> {
+    public static final IndexDocumentIntoSystemIndexAction INSTANCE = new IndexDocumentIntoSystemIndexAction();
+    public static final String NAME = "cluster:mock/systemindex/index";
+
+    private IndexDocumentIntoSystemIndexAction() {
+        super(NAME, IndexDocumentIntoSystemIndexResponse::new);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/IndexDocumentIntoSystemIndexRequest.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/IndexDocumentIntoSystemIndexRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+public class IndexDocumentIntoSystemIndexRequest extends ActionRequest {
+
+    private final String indexName;
+
+    private final String runAs;
+
+    public IndexDocumentIntoSystemIndexRequest(String indexName, String runAs) {
+        this.indexName = indexName;
+        this.runAs = runAs;
+    }
+
+    public IndexDocumentIntoSystemIndexRequest(StreamInput in) throws IOException {
+        super(in);
+        this.indexName = in.readString();
+        this.runAs = in.readOptionalString();
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public String getIndexName() {
+        return this.indexName;
+    }
+
+    public String getRunAs() {
+        return this.runAs;
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/IndexDocumentIntoSystemIndexResponse.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/IndexDocumentIntoSystemIndexResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+// CS-SUPPRESS-SINGLE: RegexpSingleline It is not possible to use phrase "cluster manager" instead of master here
+import java.io.IOException;
+
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+// CS-ENFORCE-SINGLE
+
+public class IndexDocumentIntoSystemIndexResponse extends AcknowledgedResponse implements ToXContentObject {
+
+    private String plugin;
+
+    public IndexDocumentIntoSystemIndexResponse(boolean status, String plugin) {
+        super(status);
+        this.plugin = plugin;
+    }
+
+    public IndexDocumentIntoSystemIndexResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(plugin);
+    }
+
+    @Override
+    public void addCustomFields(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        super.addCustomFields(builder, params);
+        builder.field("plugin", plugin);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/RestBulkIndexDocumentIntoMixOfSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/RestBulkIndexDocumentIntoMixOfSystemIndexAction.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import java.util.List;
+
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.security.identity.PluginContextSwitcher;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+import static org.opensearch.security.plugin.SystemIndexPlugin1.SYSTEM_INDEX_1;
+import static org.opensearch.security.plugin.SystemIndexPlugin2.SYSTEM_INDEX_2;
+
+public class RestBulkIndexDocumentIntoMixOfSystemIndexAction extends BaseRestHandler {
+
+    private final Client client;
+    private final PluginContextSwitcher contextSwitcher;
+
+    public RestBulkIndexDocumentIntoMixOfSystemIndexAction(Client client, PluginContextSwitcher contextSwitcher) {
+        this.client = client;
+        this.contextSwitcher = contextSwitcher;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(PUT, "/try-create-and-bulk-mixed-index"));
+    }
+
+    @Override
+    public String getName() {
+        return "test_bulk_index_document_into_mix_of_system_index_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        return new RestChannelConsumer() {
+
+            @Override
+            public void accept(RestChannel channel) throws Exception {
+                contextSwitcher.runAs(() -> {
+                    BulkRequestBuilder builder = client.prepareBulk();
+                    builder.add(new IndexRequest(SYSTEM_INDEX_1).source("{\"content\":1}", XContentType.JSON));
+                    builder.add(new IndexRequest(SYSTEM_INDEX_2).source("{\"content\":1}", XContentType.JSON));
+                    builder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                    BulkRequest bulkRequest = builder.request();
+                    client.bulk(bulkRequest, ActionListener.wrap(r -> {
+                        channel.sendResponse(
+                            new BytesRestResponse(RestStatus.OK, r.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS))
+                        );
+                    }, fr -> { channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, String.valueOf(fr))); }));
+                    return null;
+                });
+            }
+        };
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/RestBulkIndexDocumentIntoSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/RestBulkIndexDocumentIntoSystemIndexAction.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import java.util.List;
+
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkRequestBuilder;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.security.identity.PluginContextSwitcher;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+
+public class RestBulkIndexDocumentIntoSystemIndexAction extends BaseRestHandler {
+
+    private final Client client;
+    private final PluginContextSwitcher contextSwitcher;
+
+    public RestBulkIndexDocumentIntoSystemIndexAction(Client client, PluginContextSwitcher contextSwitcher) {
+        this.client = client;
+        this.contextSwitcher = contextSwitcher;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(PUT, "/try-create-and-bulk-index/{index}"));
+    }
+
+    @Override
+    public String getName() {
+        return "test_bulk_index_document_into_system_index_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        String indexName = request.param("index");
+        return new RestChannelConsumer() {
+
+            @Override
+            public void accept(RestChannel channel) throws Exception {
+                contextSwitcher.runAs(() -> {
+                    client.admin().indices().create(new CreateIndexRequest(indexName), ActionListener.wrap(r -> {
+                        BulkRequestBuilder builder = client.prepareBulk();
+                        builder.add(new IndexRequest(indexName).source("{\"content\":1}", XContentType.JSON));
+                        builder.add(new IndexRequest(indexName).source("{\"content\":2}", XContentType.JSON));
+                        builder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                        BulkRequest bulkRequest = builder.request();
+                        client.bulk(bulkRequest, ActionListener.wrap(r2 -> {
+                            channel.sendResponse(
+                                new BytesRestResponse(RestStatus.OK, r.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS))
+                            );
+                        }, fr -> { channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, String.valueOf(fr))); }));
+                    }, fr -> { channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, String.valueOf(fr))); }));
+                    return null;
+                });
+            }
+        };
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/RestIndexDocumentIntoSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/RestIndexDocumentIntoSystemIndexAction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import java.util.List;
+
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+
+public class RestIndexDocumentIntoSystemIndexAction extends BaseRestHandler {
+
+    private final Client client;
+
+    public RestIndexDocumentIntoSystemIndexAction(Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(PUT, "/try-create-and-index/{index}"));
+    }
+
+    @Override
+    public String getName() {
+        return "test_index_document_into_system_index_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        String runAs = request.param("runAs");
+        String indexName = request.param("index");
+        IndexDocumentIntoSystemIndexRequest indexRequest = new IndexDocumentIntoSystemIndexRequest(indexName, runAs);
+        return channel -> client.execute(IndexDocumentIntoSystemIndexAction.INSTANCE, indexRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/RestRunClusterHealthAction.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/RestRunClusterHealthAction.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import java.util.List;
+
+import org.opensearch.client.Client;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.security.identity.PluginContextSwitcher;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.GET;
+
+public class RestRunClusterHealthAction extends BaseRestHandler {
+
+    private final Client client;
+    private final PluginContextSwitcher contextSwitcher;
+
+    public RestRunClusterHealthAction(Client client, PluginContextSwitcher contextSwitcher) {
+        this.client = client;
+        this.contextSwitcher = contextSwitcher;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(GET, "/try-cluster-health/{runAs}"));
+    }
+
+    @Override
+    public String getName() {
+        return "test_run_cluster_health_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        String runAs = request.param("runAs");
+        RunClusterHealthRequest runRequest = new RunClusterHealthRequest(runAs);
+        return channel -> client.execute(RunClusterHealthAction.INSTANCE, runRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/RunClusterHealthAction.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/RunClusterHealthAction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import org.opensearch.action.ActionType;
+
+public class RunClusterHealthAction extends ActionType<RunClusterHealthResponse> {
+    public static final RunClusterHealthAction INSTANCE = new RunClusterHealthAction();
+    public static final String NAME = "cluster:mock/monitor/health";
+
+    private RunClusterHealthAction() {
+        super(NAME, RunClusterHealthResponse::new);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/RunClusterHealthRequest.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/RunClusterHealthRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+
+public class RunClusterHealthRequest extends ActionRequest {
+
+    private final String runAs;
+
+    public RunClusterHealthRequest(String runAs) {
+        this.runAs = runAs;
+    }
+
+    public RunClusterHealthRequest(StreamInput in) throws IOException {
+        super(in);
+        this.runAs = in.readString();
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public String getRunAs() {
+        return this.runAs;
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/RunClusterHealthResponse.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/RunClusterHealthResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+// CS-SUPPRESS-SINGLE: RegexpSingleline It is not possible to use phrase "cluster manager" instead of master here
+import java.io.IOException;
+
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+// CS-ENFORCE-SINGLE
+
+public class RunClusterHealthResponse extends AcknowledgedResponse implements ToXContentObject {
+
+    public RunClusterHealthResponse(boolean status) {
+        super(status);
+    }
+
+    public RunClusterHealthResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    @Override
+    public void addCustomFields(XContentBuilder builder, Params params) throws IOException {
+        super.addCustomFields(builder, params);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/SystemIndexPlugin1.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/SystemIndexPlugin1.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsFilter;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
+import org.opensearch.env.NodeEnvironment;
+import org.opensearch.identity.PluginSubject;
+import org.opensearch.indices.SystemIndexDescriptor;
+import org.opensearch.plugins.IdentityAwarePlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.SystemIndexPlugin;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.script.ScriptService;
+import org.opensearch.security.identity.PluginContextSwitcher;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.watcher.ResourceWatcherService;
+
+public class SystemIndexPlugin1 extends Plugin implements SystemIndexPlugin, IdentityAwarePlugin {
+    public static final String SYSTEM_INDEX_1 = ".system-index1";
+
+    private PluginContextSwitcher contextSwitcher;
+
+    private Client client;
+
+    @Override
+    public Collection<Object> createComponents(
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ResourceWatcherService resourceWatcherService,
+        ScriptService scriptService,
+        NamedXContentRegistry xContentRegistry,
+        Environment environment,
+        NodeEnvironment nodeEnvironment,
+        NamedWriteableRegistry namedWriteableRegistry,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<RepositoriesService> repositoriesServiceSupplier
+    ) {
+        this.client = client;
+        this.contextSwitcher = new PluginContextSwitcher();
+        return List.of(contextSwitcher);
+    }
+
+    @Override
+    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+        final SystemIndexDescriptor systemIndexDescriptor = new SystemIndexDescriptor(SYSTEM_INDEX_1, "System index 1");
+        return Collections.singletonList(systemIndexDescriptor);
+    }
+
+    @Override
+    public List<RestHandler> getRestHandlers(
+        Settings settings,
+        RestController restController,
+        ClusterSettings clusterSettings,
+        IndexScopedSettings indexScopedSettings,
+        SettingsFilter settingsFilter,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<DiscoveryNodes> nodesInCluster
+    ) {
+        return List.of(
+            new RestIndexDocumentIntoSystemIndexAction(client),
+            new RestRunClusterHealthAction(client, contextSwitcher),
+            new RestBulkIndexDocumentIntoSystemIndexAction(client, contextSwitcher),
+            new RestBulkIndexDocumentIntoMixOfSystemIndexAction(client, contextSwitcher)
+        );
+    }
+
+    @Override
+    public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        return Arrays.asList(
+            new ActionHandler<>(IndexDocumentIntoSystemIndexAction.INSTANCE, TransportIndexDocumentIntoSystemIndexAction.class),
+            new ActionHandler<>(RunClusterHealthAction.INSTANCE, TransportRunClusterHealthAction.class)
+        );
+    }
+
+    @Override
+    public void assignSubject(PluginSubject pluginSystemSubject) {
+        if (contextSwitcher != null) {
+            this.contextSwitcher.initialize(pluginSystemSubject);
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/SystemIndexPlugin2.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/SystemIndexPlugin2.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
+import org.opensearch.env.NodeEnvironment;
+import org.opensearch.indices.SystemIndexDescriptor;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.SystemIndexPlugin;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.script.ScriptService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.watcher.ResourceWatcherService;
+
+public class SystemIndexPlugin2 extends Plugin implements SystemIndexPlugin {
+    public static final String SYSTEM_INDEX_2 = ".system-index2";
+
+    private Client client;
+
+    @Override
+    public Collection<Object> createComponents(
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ResourceWatcherService resourceWatcherService,
+        ScriptService scriptService,
+        NamedXContentRegistry xContentRegistry,
+        Environment environment,
+        NodeEnvironment nodeEnvironment,
+        NamedWriteableRegistry namedWriteableRegistry,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<RepositoriesService> repositoriesServiceSupplier
+    ) {
+        this.client = client;
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+        final SystemIndexDescriptor systemIndexDescriptor = new SystemIndexDescriptor(SYSTEM_INDEX_2, "System index 2");
+        return Collections.singletonList(systemIndexDescriptor);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/TransportIndexDocumentIntoSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/TransportIndexDocumentIntoSystemIndexAction.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Client;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.identity.IdentityService;
+import org.opensearch.identity.Subject;
+import org.opensearch.security.identity.PluginContextSwitcher;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.user.User;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+public class TransportIndexDocumentIntoSystemIndexAction extends HandledTransportAction<
+    IndexDocumentIntoSystemIndexRequest,
+    IndexDocumentIntoSystemIndexResponse> {
+
+    private final Client client;
+    private final ThreadPool threadPool;
+    private final PluginContextSwitcher contextSwitcher;
+    private final IdentityService identityService;
+
+    @Inject
+    public TransportIndexDocumentIntoSystemIndexAction(
+        final TransportService transportService,
+        final ActionFilters actionFilters,
+        final Client client,
+        final ThreadPool threadPool,
+        final PluginContextSwitcher contextSwitcher,
+        final IdentityService identityService
+    ) {
+        super(IndexDocumentIntoSystemIndexAction.NAME, transportService, actionFilters, IndexDocumentIntoSystemIndexRequest::new);
+        this.client = client;
+        this.threadPool = threadPool;
+        this.contextSwitcher = contextSwitcher;
+        this.identityService = identityService;
+    }
+
+    @Override
+    protected void doExecute(
+        Task task,
+        IndexDocumentIntoSystemIndexRequest request,
+        ActionListener<IndexDocumentIntoSystemIndexResponse> actionListener
+    ) {
+        String indexName = request.getIndexName();
+        String runAs = request.getRunAs();
+        Subject userSubject = identityService.getCurrentSubject();
+        System.out.println("User Subject: " + userSubject);
+        try {
+            contextSwitcher.runAs(() -> {
+                client.admin().indices().create(new CreateIndexRequest(indexName), ActionListener.wrap(r -> {
+                    if ("user".equalsIgnoreCase(runAs)) {
+                        userSubject.runAs(() -> {
+                            client.index(
+                                new IndexRequest(indexName).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                                    .source("{\"content\":1}", XContentType.JSON),
+                                ActionListener.wrap(r2 -> {
+                                    User user = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+                                    actionListener.onResponse(new IndexDocumentIntoSystemIndexResponse(true, user.getName()));
+                                }, actionListener::onFailure)
+                            );
+                            return null;
+                        });
+                    } else {
+                        client.index(
+                            new IndexRequest(indexName).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                                .source("{\"content\":1}", XContentType.JSON),
+                            ActionListener.wrap(r2 -> {
+                                User user = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
+                                System.out.println("Test User: " + user);
+                                actionListener.onResponse(new IndexDocumentIntoSystemIndexResponse(true, user.getName()));
+                            }, actionListener::onFailure)
+                        );
+                    }
+                }, actionListener::onFailure));
+                return null;
+            });
+        } catch (Exception ex) {
+            throw new RuntimeException("Unexpected error: " + ex.getMessage());
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/TransportRunClusterHealthAction.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/TransportRunClusterHealthAction.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.plugin;
+
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.identity.IdentityService;
+import org.opensearch.identity.Subject;
+import org.opensearch.security.identity.PluginContextSwitcher;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+public class TransportRunClusterHealthAction extends HandledTransportAction<RunClusterHealthRequest, RunClusterHealthResponse> {
+
+    private final Client client;
+    private final ThreadPool threadPool;
+    private final PluginContextSwitcher contextSwitcher;
+    private final IdentityService identityService;
+
+    @Inject
+    public TransportRunClusterHealthAction(
+        final TransportService transportService,
+        final ActionFilters actionFilters,
+        final Client client,
+        final ThreadPool threadPool,
+        final PluginContextSwitcher contextSwitcher,
+        final IdentityService identityService
+    ) {
+        super(RunClusterHealthAction.NAME, transportService, actionFilters, RunClusterHealthRequest::new);
+        this.client = client;
+        this.threadPool = threadPool;
+        this.contextSwitcher = contextSwitcher;
+        this.identityService = identityService;
+    }
+
+    @Override
+    protected void doExecute(Task task, RunClusterHealthRequest request, ActionListener<RunClusterHealthResponse> actionListener) {
+        String runAs = request.getRunAs();
+        if ("user".equalsIgnoreCase(runAs)) {
+            Subject user = identityService.getCurrentSubject();
+            try {
+                user.runAs(() -> {
+                    ActionListener<ClusterHealthResponse> chr = ActionListener.wrap(
+                        r -> { actionListener.onResponse(new RunClusterHealthResponse(true)); },
+                        actionListener::onFailure
+                    );
+                    client.admin().cluster().health(new ClusterHealthRequest(), chr);
+                    return null;
+                });
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else if ("plugin".equalsIgnoreCase(runAs)) {
+            contextSwitcher.runAs(() -> {
+                ActionListener<ClusterHealthResponse> chr = ActionListener.wrap(
+                    r -> { actionListener.onResponse(new RunClusterHealthResponse(true)); },
+                    actionListener::onFailure
+                );
+                client.admin().cluster().health(new ClusterHealthRequest(), chr);
+                return null;
+            });
+        } else {
+            ActionListener<ClusterHealthResponse> chr = ActionListener.wrap(
+                r -> { actionListener.onResponse(new RunClusterHealthResponse(true)); },
+                actionListener::onFailure
+            );
+            client.admin().cluster().health(new ClusterHealthRequest(), chr);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/auth/SecurityUser.java
+++ b/src/main/java/org/opensearch/security/auth/SecurityUser.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.auth;
+
+import java.security.Principal;
+import java.util.concurrent.Callable;
+
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.identity.NamedPrincipal;
+import org.opensearch.identity.UserSubject;
+import org.opensearch.identity.tokens.AuthToken;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.user.User;
+import org.opensearch.threadpool.ThreadPool;
+
+public class SecurityUser implements UserSubject {
+    private final NamedPrincipal userPrincipal;
+    private final ThreadPool threadPool;
+    private final User user;
+
+    SecurityUser(ThreadPool threadPool, User user) {
+        this.threadPool = threadPool;
+        this.user = user;
+        this.userPrincipal = new NamedPrincipal(user.getName());
+    }
+
+    @Override
+    public void authenticate(AuthToken authToken) {
+        // not implemented
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return userPrincipal;
+    }
+
+    @Override
+    public <T> T runAs(Callable<T> callable) throws Exception {
+        try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
+            threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, user);
+            return callable.call();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/identity/ContextProvidingPluginSubject.java
+++ b/src/main/java/org/opensearch/security/identity/ContextProvidingPluginSubject.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.identity;
+
+import java.security.Principal;
+import java.util.concurrent.Callable;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.identity.NamedPrincipal;
+import org.opensearch.identity.PluginSubject;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.user.User;
+import org.opensearch.threadpool.ThreadPool;
+
+public class ContextProvidingPluginSubject implements PluginSubject {
+    private final ThreadPool threadPool;
+    private final NamedPrincipal pluginPrincipal;
+    private final User pluginUser;
+
+    public ContextProvidingPluginSubject(ThreadPool threadPool, Settings settings, Plugin plugin) {
+        super();
+        this.threadPool = threadPool;
+        String principal = "plugin:" + plugin.getClass().getCanonicalName();
+        this.pluginPrincipal = new NamedPrincipal(principal);
+        // Convention for plugin username. Prefixed with 'plugin:'. ':' is forbidden from usernames, so this
+        // guarantees that a user with this username cannot be created by other means.
+        this.pluginUser = new User(principal);
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return pluginPrincipal;
+    }
+
+    @Override
+    public <T> T runAs(Callable<T> callable) throws Exception {
+        try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
+            threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, pluginUser);
+            return callable.call();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/identity/PluginContextSwitcher.java
+++ b/src/main/java/org/opensearch/security/identity/PluginContextSwitcher.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.identity;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+import org.opensearch.identity.PluginSubject;
+
+public class PluginContextSwitcher {
+    private PluginSubject pluginSubject;
+
+    public PluginContextSwitcher() {}
+
+    public void initialize(PluginSubject pluginSubject) {
+        this.pluginSubject = pluginSubject;
+    }
+
+    public <T> T runAs(Callable<T> callable) {
+        Objects.requireNonNull(pluginSubject);
+        try {
+            return pluginSubject.runAs(callable);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/security/auth/SecurityUserTests.java
+++ b/src/test/java/org/opensearch/security/auth/SecurityUserTests.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.auth;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import org.opensearch.security.user.User;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER;
+import static org.junit.Assert.assertNull;
+
+public class SecurityUserTests {
+
+    public static boolean terminate(ThreadPool threadPool) {
+        return ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testSecurityUserSubjectRunAs() throws Exception {
+        final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+
+        User user = new User("testUser");
+
+        SecurityUser subject = new SecurityUser(threadPool, user);
+
+        assertThat(subject.getPrincipal().getName(), equalTo(user.getName()));
+
+        assertNull(threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER));
+
+        subject.runAs(() -> {
+            assertThat(threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER), equalTo(user));
+            return null;
+        });
+
+        assertNull(threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER));
+
+        terminate(threadPool);
+    }
+}

--- a/src/test/java/org/opensearch/security/identity/ContextProvidingPluginSubjectTests.java
+++ b/src/test/java/org/opensearch/security/identity/ContextProvidingPluginSubjectTests.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.identity;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.plugins.IdentityAwarePlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.security.auth.SecurityUserTests;
+import org.opensearch.security.user.User;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+public class ContextProvidingPluginSubjectTests {
+    static class TestIdentityAwarePlugin extends Plugin implements IdentityAwarePlugin {
+
+    }
+
+    @Test
+    public void testSecurityUserSubjectRunAs() throws Exception {
+        final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+
+        final Plugin testPlugin = new TestIdentityAwarePlugin();
+
+        final User pluginUser = new User("plugin:" + testPlugin.getClass().getCanonicalName());
+
+        ContextProvidingPluginSubject subject = new ContextProvidingPluginSubject(threadPool, Settings.EMPTY, testPlugin);
+
+        assertThat(subject.getPrincipal().getName(), equalTo(testPlugin.getClass().getCanonicalName()));
+
+        assertNull(threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER));
+
+        subject.runAs(() -> {
+            assertThat(threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER), equalTo(pluginUser));
+            return null;
+        });
+
+        assertNull(threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER));
+
+        SecurityUserTests.terminate(threadPool);
+    }
+
+    @Test
+    public void testPluginContextSwitcherRunAs() throws Exception {
+        final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+
+        final Plugin testPlugin = new TestIdentityAwarePlugin();
+
+        final PluginContextSwitcher contextSwitcher = new PluginContextSwitcher();
+
+        final User pluginUser = new User("plugin:" + testPlugin.getClass().getCanonicalName());
+
+        ContextProvidingPluginSubject subject = new ContextProvidingPluginSubject(threadPool, Settings.EMPTY, testPlugin);
+
+        contextSwitcher.initialize(subject);
+
+        assertNull(threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER));
+
+        subject.runAs(() -> {
+            assertThat(threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER), equalTo(pluginUser));
+            return null;
+        });
+
+        assertNull(threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER));
+
+        SecurityUserTests.terminate(threadPool);
+    }
+
+    @Test
+    public void testPluginContextSwitcherUninitializedRunAs() throws Exception {
+        final PluginContextSwitcher contextSwitcher = new PluginContextSwitcher();
+
+        assertThrows(NullPointerException.class, () -> contextSwitcher.runAs(() -> null));
+    }
+}


### PR DESCRIPTION
### Description

Companion PR in core: https://github.com/opensearch-project/OpenSearch/pull/14630

This PR by itself does not add additional functionality, it simply implements the new extension points in core and introduces a new class called `ContextProvidingPluginSubject` which populates a header in the ThreadContext with the canonical class name of the plugin that is executing code using `pluginSystemSubject.runAs(() -> { ... })`. See `./gradlew integrationTest --tests SystemIndexTests` for an example that verifies that a block of code run with `pluginSystemSubject.runAs(() -> { ... })` has contextual info in the thread context.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Issues Resolved

Related to https://github.com/opensearch-project/security/issues/4439

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] New Roles/Permissions have a corresponding security dashboards plugin PR
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
