### PR TITLE
Add a test to ensure Index Metadata is incremented if system flag flipped to true

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/SystemIndexTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SystemIndexTests.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.security.http.ExampleSystemIndexPlugin;
+import org.opensearch.security.plugin.SystemIndexPlugin1;
 import org.opensearch.test.framework.TestSecurityConfig.AuthcDomain;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
@@ -44,7 +44,7 @@ public class SystemIndexTests {
         .anonymousAuth(false)
         .authc(AUTHC_DOMAIN)
         .users(USER_ADMIN)
-        .plugin(ExampleSystemIndexPlugin.class)
+        .plugin(SystemIndexPlugin1.class)
         .nodeSettings(
             Map.of(
                 SECURITY_RESTAPI_ROLES_ENABLED,

--- a/src/integrationTest/java/org/opensearch/security/SystemIndexUpgradeTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SystemIndexUpgradeTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.security.plugin.SystemIndexPlugin1;
+import org.opensearch.test.framework.TestSecurityConfig.AuthcDomain;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_SYSTEM_INDICES_ENABLED_KEY;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class SystemIndexUpgradeTests {
+
+    public static final AuthcDomain AUTHC_DOMAIN = new AuthcDomain("basic", 0).httpAuthenticatorWithChallenge("basic").backend("internal");
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(AUTHC_DOMAIN)
+        .users(USER_ADMIN)
+        .plugin(SystemIndexPlugin1.class)
+        .nodeSettings(
+            Map.of(
+                SECURITY_RESTAPI_ROLES_ENABLED,
+                List.of("user_" + USER_ADMIN.getName() + "__" + ALL_ACCESS.getName()),
+                SECURITY_SYSTEM_INDICES_ENABLED_KEY,
+                true
+            )
+        )
+        .build();
+
+    @Before
+    public void setup() {
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            client.delete(SystemIndexPlugin1.SYSTEM_INDEX_1);
+        }
+    }
+
+    @Test
+    public void systemIndexShouldBeMarkedTrueInClusterState() {
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            client.put(SystemIndexPlugin1.SYSTEM_INDEX_1);
+            HttpResponse response = client.get("_cluster/state/metadata/" + SystemIndexPlugin1.SYSTEM_INDEX_1);
+
+            assertThat(response.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+
+            boolean isSystem = response.bodyAsJsonNode()
+                .get("metadata")
+                .get("indices")
+                .get(SystemIndexPlugin1.SYSTEM_INDEX_1)
+                .get("system")
+                .asBoolean();
+            int version = response.bodyAsJsonNode()
+                .get("metadata")
+                .get("indices")
+                .get(SystemIndexPlugin1.SYSTEM_INDEX_1)
+                .get("version")
+                .asInt();
+
+            System.out.println("response.body: " + response.getBody());
+            System.out.println("isSystem: " + isSystem);
+            System.out.println("version: " + version);
+
+            assertThat(isSystem, equalTo(true));
+        }
+
+        cluster.stop();
+
+        cluster.start();
+
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            HttpResponse catResponse = client.get("_cat/indices");
+            System.out.println("catResponse.body: " + catResponse.getBody());
+            HttpResponse putResponse = client.put(SystemIndexPlugin1.SYSTEM_INDEX_1);
+            System.out.println("putResponse.body: " + putResponse.getBody());
+            HttpResponse response = client.get("_cluster/state/metadata/" + SystemIndexPlugin1.SYSTEM_INDEX_1);
+
+            assertThat(response.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+
+            boolean isSystem = response.bodyAsJsonNode()
+                .get("metadata")
+                .get("indices")
+                .get(SystemIndexPlugin1.SYSTEM_INDEX_1)
+                .get("system")
+                .asBoolean();
+            int version = response.bodyAsJsonNode()
+                .get("metadata")
+                .get("indices")
+                .get(SystemIndexPlugin1.SYSTEM_INDEX_1)
+                .get("version")
+                .asInt();
+
+            System.out.println("response.body: " + response.getBody());
+            System.out.println("isSystem: " + isSystem);
+            System.out.println("version: " + version);
+
+            assertThat(isSystem, equalTo(true));
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/plugin/SystemIndexPlugin1.java
+++ b/src/integrationTest/java/org/opensearch/security/plugin/SystemIndexPlugin1.java
@@ -7,21 +7,24 @@
  * compatible open source license.
  *
  */
-package org.opensearch.security.http;
+
+package org.opensearch.security.plugin;
 
 import java.util.Collection;
 import java.util.Collections;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.indices.SystemIndexDescriptor;
+import org.opensearch.plugins.IdentityAwarePlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.SystemIndexPlugin;
 
-public class ExampleSystemIndexPlugin extends Plugin implements SystemIndexPlugin {
+public class SystemIndexPlugin1 extends Plugin implements SystemIndexPlugin, IdentityAwarePlugin {
+    public static final String SYSTEM_INDEX_1 = ".system-index1";
 
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-        final SystemIndexDescriptor systemIndexDescriptor = new SystemIndexDescriptor(".system-index1", "System index 1");
+        final SystemIndexDescriptor systemIndexDescriptor = new SystemIndexDescriptor(SYSTEM_INDEX_1, "System index 1");
         return Collections.singletonList(systemIndexDescriptor);
     }
 }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
@@ -163,6 +163,16 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         close();
     }
 
+    public void stop() {
+        if (localOpenSearchCluster != null && localOpenSearchCluster.isStarted()) {
+            try {
+                localOpenSearchCluster.stop();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     @Override
     public void close() {
         System.clearProperty(INIT_CONFIGURATION_DIR);
@@ -235,13 +245,17 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         return localOpenSearchCluster.getRandom();
     }
 
-    private void start() {
+    public void start() {
         try {
             NodeSettingsSupplier nodeSettingsSupplier = minimumOpenSearchSettingsSupplierFactory.minimumOpenSearchSettings(
                 sslOnly,
                 nodeSpecificOverride,
                 nodeOverride
             );
+            if (localOpenSearchCluster != null) {
+                localOpenSearchCluster.start();
+                return;
+            }
             localOpenSearchCluster = new LocalOpenSearchCluster(
                 clusterName,
                 clusterManager,

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
@@ -138,6 +138,10 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         return localOpenSearchCluster.getSnapshotDirPath();
     }
 
+    public void addPlugin(Class<? extends Plugin> plugin) {
+        this.plugins.add(plugin);
+    }
+
     @Override
     public void before() {
         if (localOpenSearchCluster == null) {
@@ -175,6 +179,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
 
     @Override
     public void close() {
+        System.out.println("Close called");
         System.clearProperty(INIT_CONFIGURATION_DIR);
         if (localOpenSearchCluster != null && localOpenSearchCluster.isStarted()) {
             try {
@@ -253,6 +258,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
                 nodeOverride
             );
             if (localOpenSearchCluster != null) {
+                localOpenSearchCluster.plugins(plugins);
                 localOpenSearchCluster.start();
                 return;
             }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -150,6 +150,14 @@ public class LocalOpenSearchCluster {
 
     public void start() throws Exception {
         log.info("Starting {}", clusterName);
+        System.out.println("Starting with nodes: " + nodes);
+        if (!nodes.isEmpty()) {
+            for (Node node : nodes) {
+                node.start();
+            }
+            started = true;
+            return;
+        }
 
         int clusterManagerNodeCount = clusterManager.getClusterManagerNodes();
         int nonClusterManagerNodeCount = clusterManager.getDataNodes() + clusterManager.getClientNodes();
@@ -427,7 +435,9 @@ public class LocalOpenSearchCluster {
         CompletableFuture<StartStage> start() {
             CompletableFuture<StartStage> completableFuture = new CompletableFuture<>();
             final Collection<Class<? extends Plugin>> mergedPlugins = nodeSettings.pluginsWithAddition(additionalPlugins);
-            this.node = new PluginAwareNode(nodeSettings.containRole(NodeRole.CLUSTER_MANAGER), getOpenSearchSettings(), mergedPlugins);
+            if (this.node == null) {
+                this.node = new PluginAwareNode(nodeSettings.containRole(NodeRole.CLUSTER_MANAGER), getOpenSearchSettings(), mergedPlugins);
+            }
 
             new Thread(new Runnable() {
 
@@ -486,10 +496,11 @@ public class LocalOpenSearchCluster {
                     running = false;
 
                     if (node != null) {
-                        node.close();
-                        boolean stopped = node.awaitClose(timeout, timeUnit);
-                        node = null;
-                        return stopped;
+                        // node.close();
+                        // boolean stopped = node.awaitClose(timeout, timeUnit);
+                        // // node = null;
+                        // return stopped;
+                        return true;
                     } else {
                         return false;
                     }


### PR DESCRIPTION
### Description

This PR is a WIP to add a test to assert that the index metadata is incremented in cases where the system flag is flipped to true.

This scenario can occur if a plugin utilizes a system index, but previously did not register with SystemIndexPlugin.getSystemIndexDescriptors. If the index already exists and a node is upgraded to a version where the plugin registers the system index with SystemIndexPlugin.getSystemIndexDescriptors, then the flag is flipped to true but the metadata version is not incremented accordingly.

Run the test using `./gradlew integrationTest --tests SystemIndexUpgradeTests -i`

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
