### PR TITLE
Only check validate of certs in the chain of the node certificates

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/config/KeyStoreConfiguration.java
+++ b/src/main/java/org/opensearch/security/ssl/config/KeyStoreConfiguration.java
@@ -18,8 +18,10 @@ import java.security.KeyStoreException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import javax.net.ssl.KeyManagerFactory;
 
 import com.google.common.collect.ImmutableList;
@@ -39,6 +41,15 @@ public interface KeyStoreConfiguration {
             KeyStoreUtils.validateKeyStoreCertificates(keyStore.v1());
         }
         return buildKeyManagerFactory(keyStore.v1(), keyStore.v2());
+    }
+
+    default Set<String> getIssuerDns() {
+        Set<String> issuerDns = new HashSet<>();
+        final List<Certificate> certificates = loadCertificates();
+        for (Certificate certificate : certificates) {
+            issuerDns.add(certificate.x509Certificate().getIssuerX500Principal().getName());
+        }
+        return issuerDns;
     }
 
     default KeyManagerFactory buildKeyManagerFactory(final KeyStore keyStore, final char[] password) {

--- a/src/main/java/org/opensearch/security/ssl/config/TrustStoreConfiguration.java
+++ b/src/main/java/org/opensearch/security/ssl/config/TrustStoreConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.TrustManagerFactory;
@@ -46,7 +47,7 @@ public interface TrustStoreConfiguration {
         }
 
         @Override
-        public TrustManagerFactory createTrustManagerFactory(boolean validateCertificates) {
+        public TrustManagerFactory createTrustManagerFactory(boolean validateCertificates, Set<String> issuerDns) {
             return null;
         }
     };
@@ -55,10 +56,10 @@ public interface TrustStoreConfiguration {
 
     List<Certificate> loadCertificates();
 
-    default TrustManagerFactory createTrustManagerFactory(boolean validateCertificates) {
+    default TrustManagerFactory createTrustManagerFactory(boolean validateCertificates, Set<String> issuerDns) {
         final var trustStore = createTrustStore();
         if (validateCertificates) {
-            KeyStoreUtils.validateKeyStoreCertificates(trustStore);
+            KeyStoreUtils.validateKeyStoreCertificates(trustStore, issuerDns);
         }
         return buildTrustManagerFactory(trustStore);
     }

--- a/src/test/java/org/opensearch/security/ssl/config/SslCertificatesLoaderTest.java
+++ b/src/test/java/org/opensearch/security/ssl/config/SslCertificatesLoaderTest.java
@@ -13,6 +13,7 @@ package org.opensearch.security.ssl.config;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import org.junit.ClassRule;
@@ -49,7 +50,7 @@ public abstract class SslCertificatesLoaderTest extends RandomizedTest {
         assertThat("Truststore configuration created", nonNull(trustStoreConfiguration));
         assertThat(trustStoreConfiguration.file(), is(expectedFile));
         assertThat(trustStoreConfiguration.loadCertificates(), containsInAnyOrder(expectedCertificates));
-        assertThat(trustStoreConfiguration.createTrustManagerFactory(true), is(notNullValue()));
+        assertThat(trustStoreConfiguration.createTrustManagerFactory(true, Set.of()), is(notNullValue()));
     }
 
     void assertKeyStoreConfiguration(


### PR DESCRIPTION
### Description

This PR updates the certificate validation checks on bootup to limit validation to only the certificates within the chain of the node certificates. In 2.18.0 there was a change that validated all certificates contained in a bundle even if they were not part of the chain from the node certificates. Since those certs are not pertinent to OpenSearch, the validation does not need to occur.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

See discussion on forum: https://forum.opensearch.org/t/is-this-an-issue-with-opensearch-or-the-security-plugin-upgrading-from-2-17-1-to-2-18-0/22395

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
