### PR TITLE
Fix issue with internal opensearch sink on single node clusters

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/InternalAuditLogTest.java
+++ b/src/integrationTest/java/org/opensearch/security/InternalAuditLogTest.java
@@ -1,0 +1,63 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.security;
+
+import java.io.IOException;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.test.framework.AuditCompliance;
+import org.opensearch.test.framework.AuditConfiguration;
+import org.opensearch.test.framework.AuditFilters;
+import org.opensearch.test.framework.TestSecurityConfig.User;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class InternalAuditLogTest {
+
+    private static final Logger log = LogManager.getLogger(InternalAuditLogTest.class);
+
+    static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER)
+        .internalAudit(
+            new AuditConfiguration(true).compliance(new AuditCompliance().enabled(true))
+                .filters(new AuditFilters().enabledRest(true).enabledTransport(true))
+        )
+        .build();
+
+    @Test
+    public void testAuditLogShouldBeGreenInSingleNodeCluster() throws IOException {
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            TestRestClient.HttpResponse indicesResponse = client.get("_cat/indices");
+
+            assertThat(indicesResponse.getBody(), containsString("security-auditlog"));
+            assertThat(indicesResponse.getBody(), containsString("green"));
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
@@ -475,6 +475,18 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
             return this;
         }
 
+        public Builder internalAudit(AuditConfiguration auditConfiguration) {
+            if (auditConfiguration != null) {
+                testSecurityConfig.audit(auditConfiguration);
+            }
+            if (auditConfiguration.isEnabled()) {
+                nodeOverrideSettingsBuilder.put("plugins.security.audit.type", "internal_opensearch");
+            } else {
+                nodeOverrideSettingsBuilder.put("plugins.security.audit.type", "noop");
+            }
+            return this;
+        }
+
         public List<TestSecurityConfig.User> getUsers() {
             return testSecurityConfig.getUsers();
         }

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2197,6 +2197,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         private static RemoteClusterService remoteClusterService;
         private static IndicesService indicesService;
         private static PitService pitService;
+        private static ClusterService clusterService;
 
         // CS-SUPPRESS-SINGLE: RegexpSingleline Extensions manager used to allow/disallow TLS connections to extensions
         private static ExtensionsManager extensionsManager;
@@ -2207,12 +2208,14 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             final TransportService remoteClusterService,
             IndicesService indicesService,
             PitService pitService,
+            ClusterService clusterService,
             ExtensionsManager extensionsManager
         ) {
             GuiceHolder.repositoriesService = repositoriesService;
             GuiceHolder.remoteClusterService = remoteClusterService.getRemoteClusterService();
             GuiceHolder.indicesService = indicesService;
             GuiceHolder.pitService = pitService;
+            GuiceHolder.clusterService = clusterService;
             GuiceHolder.extensionsManager = extensionsManager;
         }
         // CS-ENFORCE-SINGLE
@@ -2231,6 +2234,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         public static PitService getPitService() {
             return pitService;
+        }
+
+        public static ClusterService getClusterService() {
+            return clusterService;
         }
 
         // CS-SUPPRESS-SINGLE: RegexpSingleline Extensions manager used to allow/disallow TLS connections to extensions

--- a/src/main/java/org/opensearch/security/auditlog/impl/AuditLogImpl.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AuditLogImpl.java
@@ -69,7 +69,7 @@ public final class AuditLogImpl extends AbstractAuditLog {
     ) {
         super(settings, threadPool, resolver, clusterService, environment);
         this.settings = settings;
-        this.messageRouter = new AuditMessageRouter(settings, clientProvider, threadPool, configPath);
+        this.messageRouter = new AuditMessageRouter(settings, clientProvider, threadPool, configPath, clusterService);
         this.messageRouterEnabled = this.messageRouter.isEnabled();
 
         log.info("Message routing enabled: {}", this.messageRouterEnabled);

--- a/src/main/java/org/opensearch/security/auditlog/routing/AuditMessageRouter.java
+++ b/src/main/java/org/opensearch/security/auditlog/routing/AuditMessageRouter.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auditlog.config.ThreadPoolConfig;
 import org.opensearch.security.auditlog.impl.AuditCategory;
@@ -43,9 +44,15 @@ public class AuditMessageRouter {
     final SinkProvider sinkProvider;
     final AsyncStoragePool storagePool;
 
-    public AuditMessageRouter(final Settings settings, final Client clientProvider, ThreadPool threadPool, final Path configPath) {
+    public AuditMessageRouter(
+        final Settings settings,
+        final Client clientProvider,
+        ThreadPool threadPool,
+        final Path configPath,
+        final ClusterService clusterService
+    ) {
         this(
-            new SinkProvider(settings, clientProvider, threadPool, configPath),
+            new SinkProvider(settings, clientProvider, threadPool, configPath, clusterService),
             new AsyncStoragePool(ThreadPoolConfig.getConfig(settings))
         );
     }

--- a/src/main/java/org/opensearch/security/auditlog/sink/InternalOpenSearchDataStreamSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/InternalOpenSearchDataStreamSink.java
@@ -25,6 +25,7 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.ComposableIndexTemplate;
 import org.opensearch.cluster.metadata.DataStream;
 import org.opensearch.cluster.metadata.Template;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auditlog.impl.AuditMessage;
 import org.opensearch.security.support.ConfigConstants;
@@ -43,9 +44,10 @@ public final class InternalOpenSearchDataStreamSink extends AbstractInternalOpen
         final Path configPath,
         final Client clientProvider,
         ThreadPool threadPool,
-        AuditLogSink fallbackSink
+        AuditLogSink fallbackSink,
+        ClusterService clusterService
     ) {
-        super(name, settings, settingsPrefix, clientProvider, threadPool, fallbackSink, DocWriteRequest.OpType.CREATE);
+        super(name, settings, settingsPrefix, clientProvider, threadPool, fallbackSink, DocWriteRequest.OpType.CREATE, clusterService);
         Settings sinkSettings = getSinkSettings(settingsPrefix);
 
         this.dataStreamName = sinkSettings.get(ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_NAME, "opensearch-security-auditlog");

--- a/src/main/java/org/opensearch/security/auditlog/sink/InternalOpenSearchSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/InternalOpenSearchSink.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auditlog.impl.AuditMessage;
 import org.opensearch.security.support.ConfigConstants;
@@ -36,9 +37,10 @@ public final class InternalOpenSearchSink extends AbstractInternalOpenSearchSink
         final Path configPath,
         final Client clientProvider,
         ThreadPool threadPool,
-        AuditLogSink fallbackSink
+        AuditLogSink fallbackSink,
+        ClusterService clusterService
     ) {
-        super(name, settings, settingsPrefix, clientProvider, threadPool, fallbackSink, null);
+        super(name, settings, settingsPrefix, clientProvider, threadPool, fallbackSink, null, clusterService);
 
         Settings sinkSettings = getSinkSettings(settingsPrefix);
         this.index = sinkSettings.get(ConfigConstants.SECURITY_AUDIT_OPENSEARCH_INDEX, "'security-auditlog-'YYYY.MM.dd");

--- a/src/main/java/org/opensearch/security/auditlog/sink/SinkProvider.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/SinkProvider.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.support.ConfigConstants;
@@ -34,21 +35,35 @@ public class SinkProvider {
     private final ThreadPool threadPool;
     private final Path configPath;
     private final Settings settings;
+    private final ClusterService clusterService;
     final Map<String, AuditLogSink> allSinks = new HashMap<>();
     AuditLogSink defaultSink;
     AuditLogSink fallbackSink;
 
-    public SinkProvider(final Settings settings, final Client clientProvider, ThreadPool threadPool, final Path configPath) {
+    public SinkProvider(
+        final Settings settings,
+        final Client clientProvider,
+        ThreadPool threadPool,
+        final Path configPath,
+        final ClusterService clusterService
+    ) {
         this.settings = settings;
         this.clientProvider = clientProvider;
         this.threadPool = threadPool;
         this.configPath = configPath;
+        this.clusterService = clusterService;
 
         // fall back sink, make sure we don't lose messages
         String fallbackConfigPrefix = ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS + "." + FALLBACKSINK_NAME;
         Settings fallbackSinkSettings = settings.getAsSettings(fallbackConfigPrefix);
         if (!fallbackSinkSettings.isEmpty()) {
-            this.fallbackSink = createSink(FALLBACKSINK_NAME, fallbackSinkSettings.get("type"), settings, fallbackConfigPrefix + ".config");
+            this.fallbackSink = createSink(
+                FALLBACKSINK_NAME,
+                fallbackSinkSettings.get("type"),
+                settings,
+                fallbackConfigPrefix + ".config",
+                clusterService
+            );
         }
 
         // make sure we always have a fallback to write to
@@ -63,7 +78,8 @@ public class SinkProvider {
             DEFAULTSINK_NAME,
             settings.get(ConfigConstants.SECURITY_AUDIT_TYPE_DEFAULT),
             settings,
-            ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT
+            ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT,
+            clusterService
         );
         if (defaultSink == null) {
             log.error("Default endpoint could not be created, auditlog will not work properly.");
@@ -92,7 +108,8 @@ public class SinkProvider {
                 sinkName,
                 type,
                 this.settings,
-                ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS + "." + sinkName + ".config"
+                ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS + "." + sinkName + ".config",
+                clusterService
             );
             if (sink == null) {
                 log.error("Endpoint '{}' could not be created, check log file for further information.", sinkName);
@@ -128,12 +145,27 @@ public class SinkProvider {
         }
     }
 
-    private final AuditLogSink createSink(final String name, final String type, final Settings settings, final String settingsPrefix) {
+    private final AuditLogSink createSink(
+        final String name,
+        final String type,
+        final Settings settings,
+        final String settingsPrefix,
+        final ClusterService clusterService
+    ) {
         AuditLogSink sink = null;
         if (type != null) {
             switch (type.toLowerCase()) {
                 case "internal_opensearch":
-                    sink = new InternalOpenSearchSink(name, settings, settingsPrefix, configPath, clientProvider, threadPool, fallbackSink);
+                    sink = new InternalOpenSearchSink(
+                        name,
+                        settings,
+                        settingsPrefix,
+                        configPath,
+                        clientProvider,
+                        threadPool,
+                        fallbackSink,
+                        clusterService
+                    );
                     break;
                 case "internal_opensearch_data_stream":
                     sink = new InternalOpenSearchDataStreamSink(
@@ -143,7 +175,8 @@ public class SinkProvider {
                         configPath,
                         clientProvider,
                         threadPool,
-                        fallbackSink
+                        fallbackSink,
+                        clusterService
                     );
                     break;
                 case "external_opensearch":

--- a/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogiUnitTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogiUnitTest.java
@@ -114,7 +114,7 @@ public abstract class AbstractAuditlogiUnitTest extends SingleClusterTest {
     }
 
     protected AuditMessageRouter createMessageRouterComplianceEnabled(Settings settings) {
-        AuditMessageRouter router = new AuditMessageRouter(settings, null, null, null);
+        AuditMessageRouter router = new AuditMessageRouter(settings, null, null, null, null);
         router.enableRoutes(settings);
         return router;
     }

--- a/src/test/java/org/opensearch/security/auditlog/routing/RoutingConfigurationTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/routing/RoutingConfigurationTest.java
@@ -70,7 +70,7 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest {
                 )
             )
             .build();
-        AuditMessageRouter router = new AuditMessageRouter(settings, null, null, null);
+        AuditMessageRouter router = new AuditMessageRouter(settings, null, null, null, null);
         // no default sink, audit log not enabled
         assertThat(router.isEnabled(), is(false));
         assertThat(router.defaultSink, is(nullValue()));

--- a/src/test/java/org/opensearch/security/auditlog/sink/KafkaSinkTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/KafkaSinkTest.java
@@ -64,7 +64,7 @@ public class KafkaSinkTest extends AbstractAuditlogiUnitTest {
             consumer.subscribe(Arrays.asList("compliance"));
 
             Settings settings = settingsBuilder.put("path.home", ".").build();
-            SinkProvider provider = new SinkProvider(settings, null, null, null);
+            SinkProvider provider = new SinkProvider(settings, null, null, null, null);
             AuditLogSink sink = provider.getDefaultSink();
             try {
                 assertThat(sink.getClass(), is(KafkaSink.class));

--- a/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
@@ -92,7 +92,7 @@ public class SinkProviderTLSTest {
         builder.put("plugins.security.audit.endpoints.endpoint1.config.webhook.url", "https://localhost:" + port);
         builder.put("plugins.security.audit.endpoints.endpoint2.config.webhook.url", "https://localhost:" + port);
 
-        SinkProvider provider = new SinkProvider(builder.build(), null, null, null);
+        SinkProvider provider = new SinkProvider(builder.build(), null, null, null, null);
         WebhookSink defaultSink = (WebhookSink) provider.defaultSink;
         assertThat(defaultSink.verifySSL, is(true));
 

--- a/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTest.java
@@ -29,7 +29,7 @@ public class SinkProviderTest {
         Settings settings = Settings.builder()
             .loadFromPath(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/endpoints/sink/configuration_all_variants.yml"))
             .build();
-        SinkProvider provider = new SinkProvider(settings, null, null, null);
+        SinkProvider provider = new SinkProvider(settings, null, null, null, null);
 
         // make sure we have a debug sink as fallback
         assertThat(provider.fallbackSink.getClass(), is(DebugSink.class));
@@ -104,7 +104,7 @@ public class SinkProviderTest {
         Settings settings = Settings.builder()
             .loadFromPath(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/endpoints/sink/configuration_no_multiple_endpoints.yml"))
             .build();
-        SinkProvider provider = new SinkProvider(settings, null, null, null);
+        SinkProvider provider = new SinkProvider(settings, null, null, null, null);
         InternalOpenSearchSink sink = (InternalOpenSearchSink) provider.defaultSink;
         assertThat(sink.index, is("myownindex"));
         assertThat(sink.type, is("auditevents"));

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -171,6 +171,7 @@ public class SecurityInterceptorTests {
             transportService,
             mock(IndicesService.class),
             mock(PitService.class),
+            mock(ClusterService.class),
             mock(ExtensionsManager.class)
         );
         // CS-ENFORCE-SINGLE


### PR DESCRIPTION
### Description

This PR passes the `clusterService` to the Internal OpenSearch sinks to check if the auditlog index exists. If it doesn't exist, the changes in this PR will explicitly perform a CreateIndexRequest and pass index settings to ensure the auditlog index is green in single node clusters.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
