### PR TITLE
Register cluster settings listener for plugins.security.cache.ttl_minutes

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1139,6 +1139,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         final XFFResolver xffResolver = new XFFResolver(threadPool);
         backendRegistry = new BackendRegistry(settings, adminDns, xffResolver, auditLog, threadPool);
+        backendRegistry.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
         tokenManager = new SecurityTokenManager(cs, threadPool, userService);
 
         final CompatConfig compatConfig = new CompatConfig(environment, transportPassiveAuthSetting);
@@ -1484,7 +1485,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
             settings.add(Setting.boolSetting(ConfigConstants.SECURITY_DISABLED, false, Property.NodeScope, Property.Filtered));
 
-            settings.add(Setting.intSetting(ConfigConstants.SECURITY_CACHE_TTL_MINUTES, 60, 0, Property.NodeScope, Property.Filtered));
+            settings.add(SecuritySettings.CACHE_TTL_SETTING);
 
             // Security
             settings.add(

--- a/src/main/java/org/opensearch/security/support/SecuritySettings.java
+++ b/src/main/java/org/opensearch/security/support/SecuritySettings.java
@@ -28,4 +28,12 @@ public class SecuritySettings {
         Setting.Property.Dynamic
     ); // Not filtered
 
+    public static final Setting<Integer> CACHE_TTL_SETTING = Setting.intSetting(
+        ConfigConstants.SECURITY_CACHE_TTL_MINUTES,
+        60,
+        0,
+        Setting.Property.NodeScope,
+        Setting.Property.Filtered
+    ); // Not filtered
+
 }


### PR DESCRIPTION
### Description

Registering a cluster settings listener for this setting will allow it to be changed dynamically.

Updating this setting will not persist across reboots and this will only last as long as the OpenSearch process remains up. To update this setting more permanently requires modifying the setting in `opensearch.yml`

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
