### PR TITLE
Refactor ResourcePermissions to refer to action groups as access levels

### DIFF
--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRequest.java
@@ -22,16 +22,16 @@ import org.opensearch.security.spi.resources.sharing.SharedWithActionGroup;
 public class RevokeResourceAccessRequest extends ActionRequest {
 
     String resourceId;
-    SharedWithActionGroup.ActionGroupRecipients entitiesToRevoke;
+    SharedWithActionGroup.AccessLevelRecipients entitiesToRevoke;
 
-    public RevokeResourceAccessRequest(String resourceId, SharedWithActionGroup.ActionGroupRecipients entitiesToRevoke) {
+    public RevokeResourceAccessRequest(String resourceId, SharedWithActionGroup.AccessLevelRecipients entitiesToRevoke) {
         this.resourceId = resourceId;
         this.entitiesToRevoke = entitiesToRevoke;
     }
 
     public RevokeResourceAccessRequest(StreamInput in) throws IOException {
         resourceId = in.readString();
-        entitiesToRevoke = in.readNamedWriteable(SharedWithActionGroup.ActionGroupRecipients.class);
+        entitiesToRevoke = in.readNamedWriteable(SharedWithActionGroup.AccessLevelRecipients.class);
     }
 
     @Override
@@ -49,7 +49,7 @@ public class RevokeResourceAccessRequest extends ActionRequest {
         return resourceId;
     }
 
-    public SharedWithActionGroup.ActionGroupRecipients getEntitiesToRevoke() {
+    public SharedWithActionGroup.AccessLevelRecipients getEntitiesToRevoke() {
         return entitiesToRevoke;
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRestAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRestAction.java
@@ -67,7 +67,7 @@ public class RevokeResourceAccessRestAction extends BaseRestHandler {
         );
     }
 
-    private SharedWithActionGroup.ActionGroupRecipients parseRevokedEntities(Map<String, Object> source) {
+    private SharedWithActionGroup.AccessLevelRecipients parseRevokedEntities(Map<String, Object> source) {
         if (source == null || source.isEmpty()) {
             throw new IllegalArgumentException("entities_to_revoke is required and cannot be empty");
         }
@@ -85,6 +85,6 @@ public class RevokeResourceAccessRestAction extends BaseRestHandler {
                 )
             );
 
-        return new SharedWithActionGroup.ActionGroupRecipients(entitiesToRevoke);
+        return new SharedWithActionGroup.AccessLevelRecipients(entitiesToRevoke);
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRequest.java
@@ -23,16 +23,16 @@ public class ShareResourceRequest extends ActionRequest {
 
     private final String resourceId;
 
-    private final SharedWithActionGroup.ActionGroupRecipients shareWith;
+    private final SharedWithActionGroup.AccessLevelRecipients shareWith;
 
-    public ShareResourceRequest(String resourceId, SharedWithActionGroup.ActionGroupRecipients shareWith) {
+    public ShareResourceRequest(String resourceId, SharedWithActionGroup.AccessLevelRecipients shareWith) {
         this.resourceId = resourceId;
         this.shareWith = shareWith;
     }
 
     public ShareResourceRequest(StreamInput in) throws IOException {
         this.resourceId = in.readString();
-        this.shareWith = in.readNamedWriteable(SharedWithActionGroup.ActionGroupRecipients.class);
+        this.shareWith = in.readNamedWriteable(SharedWithActionGroup.AccessLevelRecipients.class);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class ShareResourceRequest extends ActionRequest {
         return this.resourceId;
     }
 
-    public SharedWithActionGroup.ActionGroupRecipients getShareWith() {
+    public SharedWithActionGroup.AccessLevelRecipients getShareWith() {
         return shareWith;
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRestAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRestAction.java
@@ -65,14 +65,14 @@ public class ShareResourceRestAction extends BaseRestHandler {
         return channel -> client.executeLocally(ShareResourceAction.INSTANCE, shareResourceRequest, new RestToXContentListener<>(channel));
     }
 
-    private SharedWithActionGroup.ActionGroupRecipients parseShareWith(Map<String, Object> source) throws IOException {
+    private SharedWithActionGroup.AccessLevelRecipients parseShareWith(Map<String, Object> source) throws IOException {
         String jsonString = XContentFactory.jsonBuilder().map(source).toString();
 
         try (
             XContentParser parser = XContentType.JSON.xContent()
                 .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString)
         ) {
-            return SharedWithActionGroup.ActionGroupRecipients.fromXContent(parser);
+            return SharedWithActionGroup.AccessLevelRecipients.fromXContent(parser);
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Invalid share_with structure: " + e.getMessage(), e);
         }

--- a/spi/src/main/java/org/opensearch/security/spi/resources/client/ResourceSharingClient.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/client/ResourceSharingClient.java
@@ -39,7 +39,7 @@ public interface ResourceSharingClient {
     void share(
         String resourceId,
         String resourceIndex,
-        SharedWithActionGroup.ActionGroupRecipients recipients,
+        SharedWithActionGroup.AccessLevelRecipients recipients,
         ActionListener<ResourceSharing> listener
     );
 
@@ -53,7 +53,7 @@ public interface ResourceSharingClient {
     void revoke(
         String resourceId,
         String resourceIndex,
-        SharedWithActionGroup.ActionGroupRecipients entitiesToRevoke,
+        SharedWithActionGroup.AccessLevelRecipients entitiesToRevoke,
         ActionListener<ResourceSharing> listener
     );
 

--- a/spi/src/test/java/org/opensearch/security/spi/resources/ShareWithTests.java
+++ b/spi/src/test/java/org/opensearch/security/spi/resources/ShareWithTests.java
@@ -10,7 +10,7 @@ package org.opensearch.security.spi.resources;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,13 +32,13 @@ import org.opensearch.security.spi.resources.sharing.SharedWithActionGroup;
 import org.mockito.Mockito;
 
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -61,16 +61,12 @@ public class ShareWithTests {
         ShareWith shareWith = ShareWith.fromXContent(parser);
 
         MatcherAssert.assertThat(shareWith, notNullValue());
-        Set<SharedWithActionGroup> sharedWithActionGroups = shareWith.getSharedWithActionGroups();
-        MatcherAssert.assertThat(sharedWithActionGroups, notNullValue());
-        MatcherAssert.assertThat(1, equalTo(sharedWithActionGroups.size()));
+        SharedWithActionGroup readOnly = shareWith.atAccessLevel("read_only");
+        MatcherAssert.assertThat(readOnly, notNullValue());
 
-        SharedWithActionGroup actionGroup = sharedWithActionGroups.iterator().next();
-        MatcherAssert.assertThat("read_only", equalTo(actionGroup.getActionGroup()));
-
-        SharedWithActionGroup.ActionGroupRecipients actionGroupRecipients = actionGroup.getSharedWithPerActionGroup();
-        MatcherAssert.assertThat(actionGroupRecipients, notNullValue());
-        Map<Recipient, Set<String>> recipients = actionGroupRecipients.getRecipients();
+        SharedWithActionGroup.AccessLevelRecipients accessLevelRecipients = readOnly.getSharedWith();
+        MatcherAssert.assertThat(accessLevelRecipients, notNullValue());
+        Map<Recipient, Set<String>> recipients = accessLevelRecipients.getRecipients();
         MatcherAssert.assertThat(recipients.get(Recipient.USERS).size(), is(1));
         MatcherAssert.assertThat(recipients.get(Recipient.USERS), contains("user1"));
         MatcherAssert.assertThat(recipients.get(Recipient.ROLES).size(), is(0));
@@ -85,7 +81,8 @@ public class ShareWithTests {
         ShareWith result = ShareWith.fromXContent(parser);
 
         MatcherAssert.assertThat(result, notNullValue());
-        MatcherAssert.assertThat(result.getSharedWithActionGroups(), is(empty()));
+        MatcherAssert.assertThat(result.isPrivate(), is(true));
+        MatcherAssert.assertThat(result.isPublic(), is(false));
     }
 
     @Test
@@ -98,7 +95,7 @@ public class ShareWithTests {
                 .array("roles", "role1")
                 .array("backend_roles", "backend_role1")
                 .endObject()
-                .startObject("random-action-group")
+                .startObject("read-only")
                 .array("users", "*")
                 .array("roles", "*")
                 .array("backend_roles", "*")
@@ -113,22 +110,21 @@ public class ShareWithTests {
         ShareWith shareWith = ShareWith.fromXContent(parser);
 
         MatcherAssert.assertThat(shareWith, notNullValue());
-        Set<SharedWithActionGroup> actionGroups = shareWith.getSharedWithActionGroups();
-        MatcherAssert.assertThat(actionGroups.size(), equalTo(2));
 
-        for (SharedWithActionGroup actionGroup : actionGroups) {
-            SharedWithActionGroup.ActionGroupRecipients perScope = actionGroup.getSharedWithPerActionGroup();
-            Map<Recipient, Set<String>> recipients = perScope.getRecipients();
-            if (actionGroup.getActionGroup().equals(ResourceAccessActionGroups.PLACE_HOLDER)) {
-                MatcherAssert.assertThat(recipients.get(Recipient.USERS).size(), is(2));
-                MatcherAssert.assertThat(recipients.get(Recipient.ROLES).size(), is(1));
-                MatcherAssert.assertThat(recipients.get(Recipient.BACKEND_ROLES).size(), is(1));
-            } else if (actionGroup.getActionGroup().equals("random-action-group")) {
-                MatcherAssert.assertThat(recipients.get(Recipient.USERS).size(), is(1));
-                MatcherAssert.assertThat(recipients.get(Recipient.ROLES).size(), is(1));
-                MatcherAssert.assertThat(recipients.get(Recipient.BACKEND_ROLES).size(), is(1));
-            }
-        }
+        SharedWithActionGroup defaultAccessLevel = shareWith.atAccessLevel(ResourceAccessActionGroups.PLACE_HOLDER);
+
+        SharedWithActionGroup readOnly = shareWith.atAccessLevel("read-only");
+
+        MatcherAssert.assertThat(defaultAccessLevel, notNullValue());
+        MatcherAssert.assertThat(readOnly, notNullValue());
+
+        MatcherAssert.assertThat(defaultAccessLevel.getRecipientsByType(Recipient.USERS).size(), is(2));
+        MatcherAssert.assertThat(defaultAccessLevel.getRecipientsByType(Recipient.ROLES).size(), is(1));
+        MatcherAssert.assertThat(defaultAccessLevel.getRecipientsByType(Recipient.BACKEND_ROLES).size(), is(1));
+
+        MatcherAssert.assertThat(readOnly.getRecipientsByType(Recipient.USERS).size(), is(1));
+        MatcherAssert.assertThat(readOnly.getRecipientsByType(Recipient.ROLES).size(), is(1));
+        MatcherAssert.assertThat(readOnly.getRecipientsByType(Recipient.BACKEND_ROLES).size(), is(1));
     }
 
     @Test
@@ -140,20 +136,18 @@ public class ShareWithTests {
         ShareWith result = ShareWith.fromXContent(mockParser);
 
         MatcherAssert.assertThat(result, notNullValue());
-        MatcherAssert.assertThat(result.getSharedWithActionGroups(), is(empty()));
+        MatcherAssert.assertThat(result.isPrivate(), is(true));
+        MatcherAssert.assertThat(result.isPublic(), is(false));
     }
 
     @Test
     public void testToXContentBuildsCorrectly() throws IOException {
         SharedWithActionGroup actionGroup = new SharedWithActionGroup(
             "actionGroup1",
-            new SharedWithActionGroup.ActionGroupRecipients(Map.of(Recipient.USERS, Set.of("bleh")))
+            new SharedWithActionGroup.AccessLevelRecipients(Map.of(Recipient.USERS, Set.of("bleh")))
         );
 
-        Set<SharedWithActionGroup> actionGroups = new HashSet<>();
-        actionGroups.add(actionGroup);
-
-        ShareWith shareWith = new ShareWith(actionGroups);
+        ShareWith shareWith = new ShareWith(Map.of("actionGroup1", actionGroup));
 
         XContentBuilder builder = JsonXContent.contentBuilder();
 
@@ -169,39 +163,42 @@ public class ShareWithTests {
 
     @Test
     public void testWriteToWithEmptySet() throws IOException {
-        Set<SharedWithActionGroup> emptySet = Collections.emptySet();
-        ShareWith shareWith = new ShareWith(emptySet);
+        Map<String, SharedWithActionGroup> emptyMap = Collections.emptyMap();
+        ShareWith shareWith = new ShareWith(emptyMap);
         StreamOutput mockOutput = Mockito.mock(StreamOutput.class);
 
         shareWith.writeTo(mockOutput);
 
-        verify(mockOutput).writeCollection(emptySet);
+        verify(mockOutput).writeMap(eq(emptyMap), any(), any());
     }
 
     @Test
     public void testWriteToWithIOException() throws IOException {
-        Set<SharedWithActionGroup> set = new HashSet<>();
-        set.add(new SharedWithActionGroup("test", new SharedWithActionGroup.ActionGroupRecipients(Map.of())));
-        ShareWith shareWith = new ShareWith(set);
+        SharedWithActionGroup accessLevel = new SharedWithActionGroup("test", new SharedWithActionGroup.AccessLevelRecipients(Map.of()));
+        Map<String, SharedWithActionGroup> map = Map.of("test", accessLevel);
+        ShareWith shareWith = new ShareWith(map);
         StreamOutput mockOutput = Mockito.mock(StreamOutput.class);
 
-        doThrow(new IOException("Simulated IO exception")).when(mockOutput).writeCollection(set);
+        doThrow(new IOException("Simulated IO exception")).when(mockOutput).writeMap(eq(map), any(), any());
 
         assertThrows(IOException.class, () -> shareWith.writeTo(mockOutput));
     }
 
     @Test
     public void testWriteToWithLargeSet() throws IOException {
-        Set<SharedWithActionGroup> largeSet = new HashSet<>();
-        for (int i = 0; i < 10000; i++) {
-            largeSet.add(new SharedWithActionGroup("actionGroup" + i, new SharedWithActionGroup.ActionGroupRecipients(Map.of())));
+        Map<String, SharedWithActionGroup> largeMap = new HashMap<>();
+        for (int i = 0; i < 10; i++) {
+            largeMap.put(
+                "actionGroup" + i,
+                new SharedWithActionGroup("actionGroup" + i, new SharedWithActionGroup.AccessLevelRecipients(Map.of()))
+            );
         }
-        ShareWith shareWith = new ShareWith(largeSet);
+        ShareWith shareWith = new ShareWith(largeMap);
         StreamOutput mockOutput = Mockito.mock(StreamOutput.class);
 
         shareWith.writeTo(mockOutput);
 
-        verify(mockOutput).writeCollection(largeSet);
+        verify(mockOutput).writeMap(eq(largeMap), any(), any());
     }
 
     @Test
@@ -214,23 +211,24 @@ public class ShareWithTests {
 
         ShareWith shareWith = ShareWith.fromXContent(parser);
 
-        MatcherAssert.assertThat(shareWith.getSharedWithActionGroups(), is(empty()));
+        MatcherAssert.assertThat(shareWith.isPrivate(), is(true));
+        MatcherAssert.assertThat(shareWith.isPublic(), is(false));
     }
 
     @Test
     public void test_writeSharedWithScopesToStream() throws IOException {
         StreamOutput mockStreamOutput = Mockito.mock(StreamOutput.class);
 
-        Set<SharedWithActionGroup> sharedWithActionGroups = new HashSet<>();
-        sharedWithActionGroups.add(
-            new SharedWithActionGroup(ResourceAccessActionGroups.PLACE_HOLDER, new SharedWithActionGroup.ActionGroupRecipients(Map.of()))
+        Map<String, SharedWithActionGroup> map = Map.of(
+            ResourceAccessActionGroups.PLACE_HOLDER,
+            new SharedWithActionGroup(ResourceAccessActionGroups.PLACE_HOLDER, new SharedWithActionGroup.AccessLevelRecipients(Map.of()))
         );
 
-        ShareWith shareWith = new ShareWith(sharedWithActionGroups);
+        ShareWith shareWith = new ShareWith(map);
 
         shareWith.writeTo(mockStreamOutput);
 
-        verify(mockStreamOutput, times(1)).writeCollection(eq(sharedWithActionGroups));
+        verify(mockStreamOutput, times(1)).writeMap(eq(map), any(), any());
     }
 }
 

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessControlClient.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessControlClient.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.security.resources;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
@@ -52,7 +53,7 @@ public final class ResourceAccessControlClient implements ResourceSharingClient 
      */
     @Override
     public void verifyResourceAccess(String resourceId, String resourceIndex, ActionListener<Boolean> listener) {
-        resourceAccessHandler.hasPermission(resourceId, resourceIndex, Set.of(ResourceAccessActionGroups.PLACE_HOLDER), listener);
+        resourceAccessHandler.hasPermission(resourceId, resourceIndex, ResourceAccessActionGroups.PLACE_HOLDER, listener);
     }
 
     /**
@@ -67,11 +68,11 @@ public final class ResourceAccessControlClient implements ResourceSharingClient 
     public void share(
         String resourceId,
         String resourceIndex,
-        SharedWithActionGroup.ActionGroupRecipients recipients,
+        SharedWithActionGroup.AccessLevelRecipients recipients,
         ActionListener<ResourceSharing> listener
     ) {
         SharedWithActionGroup sharedWithActionGroup = new SharedWithActionGroup(ResourceAccessActionGroups.PLACE_HOLDER, recipients);
-        ShareWith shareWith = new ShareWith(Set.of(sharedWithActionGroup));
+        ShareWith shareWith = new ShareWith(Map.of(ResourceAccessActionGroups.PLACE_HOLDER, sharedWithActionGroup));
 
         resourceAccessHandler.shareWith(resourceId, resourceIndex, shareWith, listener);
     }
@@ -88,7 +89,7 @@ public final class ResourceAccessControlClient implements ResourceSharingClient 
     public void revoke(
         String resourceId,
         String resourceIndex,
-        SharedWithActionGroup.ActionGroupRecipients entitiesToRevoke,
+        SharedWithActionGroup.AccessLevelRecipients entitiesToRevoke,
         ActionListener<ResourceSharing> listener
     ) {
         resourceAccessHandler.revokeAccess(

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
@@ -120,13 +120,13 @@ public class ResourceAccessHandler {
      *
      * @param resourceId    The resource ID to check access for.
      * @param resourceIndex The resource index containing the resource.
-     * @param actionGroups  The set of action groups to check permission for.
+     * @param accessLevel   The access level to check permission for.
      * @param listener      The listener to be notified with the permission check result.
      */
     public void hasPermission(
         @NonNull String resourceId,
         @NonNull String resourceIndex,
-        @NonNull Set<String> actionGroups,
+        @NonNull String accessLevel,
         ActionListener<Boolean> listener
     ) {
         final UserSubjectImpl userSubject = (UserSubjectImpl) threadContext.getPersistent(
@@ -168,9 +168,9 @@ public class ResourceAccessHandler {
             userBackendRoles.add("*");
             if (document.isCreatedBy(user.getName())
                 || document.isSharedWithEveryone()
-                || document.isSharedWithEntity(Recipient.USERS, Set.of(user.getName(), "*"), actionGroups)
-                || document.isSharedWithEntity(Recipient.ROLES, userRoles, actionGroups)
-                || document.isSharedWithEntity(Recipient.BACKEND_ROLES, userBackendRoles, actionGroups)) {
+                || document.isSharedWithEntity(Recipient.USERS, Set.of(user.getName(), "*"), accessLevel)
+                || document.isSharedWithEntity(Recipient.ROLES, userRoles, accessLevel)
+                || document.isSharedWithEntity(Recipient.BACKEND_ROLES, userBackendRoles, accessLevel)) {
 
                 LOGGER.debug("User '{}' has permission to resource '{}'", user.getName(), resourceId);
                 listener.onResponse(true);
@@ -251,7 +251,7 @@ public class ResourceAccessHandler {
     public void revokeAccess(
         @NonNull String resourceId,
         @NonNull String resourceIndex,
-        @NonNull SharedWithActionGroup.ActionGroupRecipients revokeAccess,
+        @NonNull SharedWithActionGroup.AccessLevelRecipients revokeAccess,
         @NonNull Set<String> actionGroups,
         ActionListener<ResourceSharing> listener
     ) {

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -478,7 +478,7 @@ public class ResourceSharingIndexHandler {
 
     /**
      * Updates the sharing configuration for an existing resource in the resource sharing index.
-     * NOTE: This method only grants new access. To remove access use {@link #revokeAccess(String, String, org.opensearch.security.spi.resources.sharing.SharedWithActionGroup.ActionGroupRecipients, Set, String, boolean, ActionListener)}
+     * NOTE: This method only grants new access. To remove access use {@link #revokeAccess(String, String, SharedWithActionGroup.AccessLevelRecipients, Set, String, boolean, ActionListener)}
      * This method modifies the sharing permissions for a specific resource identified by its
      * resource ID and source index.
      *
@@ -609,7 +609,7 @@ public class ResourceSharingIndexHandler {
     public void revokeAccess(
         String resourceId,
         String sourceIdx,
-        SharedWithActionGroup.ActionGroupRecipients revokeAccess,
+        SharedWithActionGroup.AccessLevelRecipients revokeAccess,
         Set<String> actionGroups,
         String requestUserName,
         boolean isAdmin,


### PR DESCRIPTION
### Description

This PR does a bit of a refactor on https://github.com/opensearch-project/security/pull/5281 to refer to action groups as "access levels". In the context of sharable resources, I think access level helps to differentiate these from other action groups as they would be pertinent to sharable resources.

This also fixes a bug in the logic of ResourceSharing.isSharedWithEveryone

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Refactor

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
