### PR TITLE
Always install demo certs if configured with demo certs

### DIFF
--- a/src/main/java/org/opensearch/security/tools/democonfig/CertificateGenerator.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/CertificateGenerator.java
@@ -33,6 +33,11 @@ public class CertificateGenerator {
     public void createDemoCertificates() {
         for (Certificates cert : Certificates.values()) {
             String filePath = this.installer.OPENSEARCH_CONF_DIR + File.separator + cert.getFileName();
+            File file = new File(filePath);
+            if (file.exists()) {
+                System.out.println("File " + filePath + " already exists. Skipping.");
+                continue;
+            }
             try {
                 FileWriter fileWriter = new FileWriter(filePath, StandardCharsets.UTF_8);
                 fileWriter.write(cert.getContent());

--- a/src/main/java/org/opensearch/security/tools/democonfig/Installer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/Installer.java
@@ -41,7 +41,7 @@ public class Installer {
     private static Installer instance;
 
     private static SecuritySettingsConfigurer securitySettingsConfigurer;
-    private static CertificateGenerator certificateGenerator;
+    static CertificateGenerator certificateGenerator;
 
     boolean assumeyes = false;
     boolean initsecurity = false;

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -37,6 +37,7 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import static org.opensearch.security.DefaultObjectMapper.YAML_MAPPER;
+import static org.opensearch.security.tools.democonfig.Installer.certificateGenerator;
 
 /**
  * This class updates the security related configuration, as needed.
@@ -105,6 +106,52 @@ public class SecuritySettingsConfigurer {
         writeSecurityConfigToOpenSearchYML();
     }
 
+    boolean isSecurityPluginIsConfiguredWithDemoCerts() {
+        if (installer.OPENSEARCH_CONF_FILE == null || !new File(installer.OPENSEARCH_CONF_FILE).exists()) {
+            return false;
+        }
+
+        try (BufferedReader br = new BufferedReader(new FileReader(installer.OPENSEARCH_CONF_FILE, StandardCharsets.UTF_8))) {
+            Yaml yaml = new Yaml();
+            Map<String, Object> yamlData = yaml.load(br);
+            if (yamlData == null) return false;
+
+            String[] requiredSettings = {
+                "plugins.security.ssl.transport.pemcert_filepath",
+                "plugins.security.ssl.transport.pemkey_filepath",
+                "plugins.security.ssl.transport.pemtrustedcas_filepath",
+                "plugins.security.ssl.http.pemcert_filepath",
+                "plugins.security.ssl.http.pemkey_filepath",
+                "plugins.security.ssl.http.pemtrustedcas_filepath" };
+
+            String[] expectedValues = { "esnode.pem", "esnode-key.pem", "root-ca.pem", "esnode.pem", "esnode-key.pem", "root-ca.pem" };
+
+            for (int i = 0; i < requiredSettings.length; i++) {
+                String value = getNestedValue(yamlData, requiredSettings[i]);
+                if (!expectedValues[i].equals(value)) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String getNestedValue(Map<String, Object> yamlData, String key) {
+        String[] parts = key.split("\\.");
+        Object current = yamlData;
+        for (String part : parts) {
+            if (current instanceof Map) {
+                current = ((Map<String, Object>) current).get(part);
+            } else {
+                return null;
+            }
+        }
+        return current instanceof String ? (String) current : null;
+    }
+
     /**
      * Checks if security plugin is already configured. If so, the script execution will exit.
      */
@@ -119,6 +166,9 @@ public class SecuritySettingsConfigurer {
                     // Check for flat keys
                     for (String key : yamlData.keySet()) {
                         if (key.startsWith("plugins.security")) {
+                            if (isSecurityPluginIsConfiguredWithDemoCerts()) {
+                                certificateGenerator.createDemoCertificates();
+                            }
                             System.out.println(installer.OPENSEARCH_CONF_FILE + " seems to be already configured for Security. Quit.");
                             installer.getExitHandler().exit(installer.skip_updates);
                         }
@@ -128,6 +178,9 @@ public class SecuritySettingsConfigurer {
                         Map<String, Object> plugins = (Map<String, Object>) yamlData.get("plugins");
                         for (String key : plugins.keySet()) {
                             if (key.startsWith("security")) {
+                                if (isSecurityPluginIsConfiguredWithDemoCerts()) {
+                                    certificateGenerator.createDemoCertificates();
+                                }
                                 System.out.println(installer.OPENSEARCH_CONF_FILE + " seems to be already configured for Security. Quit.");
                                 installer.getExitHandler().exit(installer.skip_updates);
                             }


### PR DESCRIPTION
### Description

This PR updates the demo installer to _always_ install the demo certs into the `config/` folder even if the following settings are already present in `opensearch.yml`

```
/**
   * plugins.security.ssl.transport.pemcert_filepath: esnode.pem
   * plugins.security.ssl.transport.pemkey_filepath: esnode-key.pem
   * plugins.security.ssl.transport.pemtrustedcas_filepath: root-ca.pem
   * plugins.security.ssl.http.pemcert_filepath: esnode.pem
   * plugins.security.ssl.http.pemkey_filepath: esnode-key.pem
   * plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem
   */
```

By ensuring that the files are always copied, it resolves an issue seen in the helm-charts repo where the values are already present in `opensearch.yml` but the certs are not written to the `config/` folder in the event that the opensearch process dies on one of the pods and is replaced. The reason for that is that it goes through the installation script and aborts saying that security is already configured.

### Issues Resolved

Resolves: https://github.com/opensearch-project/security/issues/5044

Helm Charts: https://github.com/opensearch-project/helm-charts/issues/680

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
