### PR TITLE
[Resource Sharing] Add alias and wildcard support for resource indices

### DIFF
--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -105,6 +105,20 @@ public final class TestUtils {
     }
 
     public static LocalCluster newCluster(boolean featureEnabled, boolean systemIndexEnabled, List<String> protectedResourceTypes) {
+        return newCluster(featureEnabled, systemIndexEnabled, protectedResourceTypes, Map.of());
+    }
+
+    public static LocalCluster newCluster(
+        boolean featureEnabled,
+        boolean systemIndexEnabled,
+        List<String> protectedResourceTypes,
+        Map<String, Object> extraSettings
+    ) {
+        Map<String, Object> settings = new HashMap<>();
+        settings.put(OPENSEARCH_RESOURCE_SHARING_ENABLED, featureEnabled);
+        settings.put(SECURITY_SYSTEM_INDICES_ENABLED_KEY, systemIndexEnabled);
+        settings.put(OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES, protectedResourceTypes);
+        settings.putAll(extraSettings);
         return new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS_COORDINATOR)
             .plugin(
                 new PluginInfo(
@@ -122,16 +136,7 @@ public final class TestUtils {
             .anonymousAuth(true)
             .authc(AUTHC_HTTPBASIC_INTERNAL)
             .users(USER_ADMIN, FULL_ACCESS_USER, LIMITED_ACCESS_USER, NO_ACCESS_USER)
-            .nodeSettings(
-                Map.of(
-                    OPENSEARCH_RESOURCE_SHARING_ENABLED,
-                    featureEnabled,
-                    SECURITY_SYSTEM_INDICES_ENABLED_KEY,
-                    systemIndexEnabled,
-                    OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES,
-                    protectedResourceTypes
-                )
-            )
+            .nodeSettings(settings)
             .build();
     }
 
@@ -441,6 +446,20 @@ public final class TestUtils {
         public TestRestClient.HttpResponse searchResources(TestSecurityConfig.User user) {
             try (TestRestClient client = cluster.getRestClient(user)) {
                 return client.get(SAMPLE_RESOURCE_SEARCH_ENDPOINT);
+            }
+        }
+
+        public TestRestClient.HttpResponse searchResourcesByAlias(String alias, TestSecurityConfig.User user) {
+            try (TestRestClient client = cluster.getRestClient(user)) {
+                return client.get(SAMPLE_RESOURCE_SEARCH_ENDPOINT + "?index=" + alias);
+            }
+        }
+
+        public void createIndexWithAlias(String concreteIndex, String alias) {
+            try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+                String body = "{\"aliases\":{\"" + alias + "\":{}}}";
+                TestRestClient.HttpResponse response = client.putJson(concreteIndex, body);
+                assertThat(response.getStatusCode(), is(200));
             }
         }
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/AliasIndexPatternTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/AliasIndexPatternTests.java
@@ -1,0 +1,213 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource.feature.enabled;
+
+import java.util.List;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.sample.SampleResourcePlugin;
+import org.opensearch.sample.resource.TestUtils;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY;
+import static org.opensearch.sample.resource.TestUtils.newCluster;
+import static org.opensearch.sample.utils.Constants.RESOURCE_GROUP_TYPE;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_CONCRETE;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
+import static org.opensearch.security.api.AbstractApiIntegrationTest.forbidden;
+import static org.opensearch.security.api.AbstractApiIntegrationTest.ok;
+import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
+
+/**
+ * Tests resource sharing when the plugin uses an alias (.sample_resource) backed by
+ * a concrete index (.sample_resource_1) with a wildcard pattern (.sample_resource_*).
+ * This validates the wildcard index pattern support end-to-end.
+ */
+@RunWith(RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class AliasIndexPatternTests {
+
+    @ClassRule
+    public static LocalCluster cluster = newCluster(
+        true,
+        true,
+        List.of(RESOURCE_TYPE, RESOURCE_GROUP_TYPE),
+        Map.of(SampleResourcePlugin.ALIAS_MODE_SETTING_KEY, true)
+    );
+
+    private static final TestUtils.ApiHelper staticApi = new TestUtils.ApiHelper(cluster);
+    private final TestUtils.ApiHelper api = new TestUtils.ApiHelper(cluster);
+    private String resourceId;
+
+    @BeforeClass
+    public static void setupAlias() {
+        // Create concrete index with alias, mimicking the .kibana pattern
+        staticApi.createIndexWithAlias(RESOURCE_INDEX_CONCRETE, RESOURCE_INDEX_NAME);
+    }
+
+    @Before
+    public void setup() {
+        resourceId = api.createSampleResourceAs(USER_ADMIN);
+        api.awaitSharingEntry(resourceId);
+    }
+
+    @After
+    public void cleanup() {
+        api.wipeOutResourceEntries();
+    }
+
+    // --- Helper methods mirroring normal-mode test patterns ---
+
+    private void assertNoAccess(TestSecurityConfig.User user) throws Exception {
+        forbidden(() -> api.getResource(resourceId, user));
+        forbidden(() -> api.updateResource(resourceId, user, "nope"));
+        forbidden(() -> api.deleteResource(resourceId, user));
+        forbidden(() -> api.shareResource(resourceId, user, user, SAMPLE_FULL_ACCESS));
+        forbidden(() -> api.revokeResource(resourceId, user, user, SAMPLE_FULL_ACCESS));
+    }
+
+    private void assertReadOnly(TestSecurityConfig.User user) throws Exception {
+        TestRestClient.HttpResponse response = ok(() -> api.getResource(resourceId, user));
+        assertThat(response.getBody(), containsString("sample"));
+        forbidden(() -> api.updateResource(resourceId, user, "nope"));
+        forbidden(() -> api.deleteResource(resourceId, user));
+        forbidden(() -> api.shareResource(resourceId, user, user, SAMPLE_FULL_ACCESS));
+        forbidden(() -> api.revokeResource(resourceId, user, user, SAMPLE_FULL_ACCESS));
+    }
+
+    private void assertFullAccess(TestSecurityConfig.User user) throws Exception {
+        TestRestClient.HttpResponse response = ok(() -> api.getResource(resourceId, user));
+        assertThat(response.getBody(), containsString("sample"));
+        ok(() -> api.updateResource(resourceId, user, "updated"));
+        ok(() -> api.shareResource(resourceId, user, user, SAMPLE_FULL_ACCESS));
+        ok(() -> api.revokeResource(resourceId, user, USER_ADMIN, SAMPLE_FULL_ACCESS));
+        ok(() -> api.deleteResource(resourceId, user));
+    }
+
+    // --- Owner CRUD ---
+
+    @Test
+    public void owner_canCRUD() throws Exception {
+        TestRestClient.HttpResponse response = ok(() -> api.getResource(resourceId, USER_ADMIN));
+        assertThat(response.getBody(), containsString("sample"));
+        ok(() -> api.updateResource(resourceId, USER_ADMIN, "updated"));
+        ok(() -> api.deleteResource(resourceId, USER_ADMIN));
+    }
+
+    // --- Full access sharing ---
+
+    @Test
+    public void fullAccess_sharing_and_revoke() throws Exception {
+        assertNoAccess(FULL_ACCESS_USER);
+
+        ok(() -> api.shareResource(resourceId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_FULL_ACCESS));
+
+        // Shared user can share transitively
+        ok(() -> api.shareResource(resourceId, FULL_ACCESS_USER, LIMITED_ACCESS_USER, SAMPLE_FULL_ACCESS));
+
+        // Revoke and verify
+        ok(() -> api.revokeResource(resourceId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_FULL_ACCESS));
+        forbidden(() -> api.getResource(resourceId, FULL_ACCESS_USER));
+    }
+
+    @Test
+    public void fullAccess_user_canCRUD() throws Exception {
+        assertNoAccess(FULL_ACCESS_USER);
+        ok(() -> api.shareResource(resourceId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_FULL_ACCESS));
+        assertFullAccess(FULL_ACCESS_USER);
+    }
+
+    // --- Read-only access ---
+
+    @Test
+    public void readOnly_fullAccessUser() throws Exception {
+        assertNoAccess(FULL_ACCESS_USER);
+        ok(() -> api.shareResource(resourceId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_READ_ONLY));
+        assertReadOnly(FULL_ACCESS_USER);
+    }
+
+    @Test
+    public void readOnly_limitedAccessUser() throws Exception {
+        assertNoAccess(LIMITED_ACCESS_USER);
+        ok(() -> api.shareResource(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY));
+        assertReadOnly(LIMITED_ACCESS_USER);
+    }
+
+    @Test
+    public void readOnly_noAccessUser() throws Exception {
+        assertNoAccess(NO_ACCESS_USER);
+        ok(() -> api.shareResource(resourceId, USER_ADMIN, NO_ACCESS_USER, SAMPLE_READ_ONLY));
+        assertReadOnly(NO_ACCESS_USER);
+    }
+
+    // --- Mixed access levels ---
+
+    @Test
+    public void mixed_readOnly_then_upgraded_to_fullAccess() throws Exception {
+        assertNoAccess(LIMITED_ACCESS_USER);
+
+        // Start with read-only
+        ok(() -> api.shareResource(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY));
+        assertReadOnly(LIMITED_ACCESS_USER);
+
+        // Upgrade to full access
+        ok(() -> api.shareResource(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_FULL_ACCESS));
+        assertFullAccess(LIMITED_ACCESS_USER);
+    }
+
+    @Test
+    public void mixed_multipleUsers_differentLevels() throws Exception {
+        assertNoAccess(FULL_ACCESS_USER);
+        assertNoAccess(LIMITED_ACCESS_USER);
+
+        // Share read-only to one, full-access to another
+        ok(() -> api.shareResource(resourceId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_READ_ONLY));
+        ok(() -> api.shareResource(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_FULL_ACCESS));
+
+        assertReadOnly(FULL_ACCESS_USER);
+
+        // Full-access user upgrades read-only user
+        ok(() -> api.shareResource(resourceId, LIMITED_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_FULL_ACCESS));
+        assertFullAccess(FULL_ACCESS_USER);
+    }
+
+    // --- DLS filtering through alias ---
+
+    @Test
+    public void dls_owner_sees_own_resource_via_plugin_search() throws Exception {
+        // Owner should see their resource via the plugin search API
+        TestRestClient.HttpResponse response = ok(() -> api.searchResources(USER_ADMIN));
+        assertThat(response.getBody(), containsString("sample"));
+    }
+
+    @Test
+    public void dls_nonShared_user_sees_nothing_via_plugin_search() throws Exception {
+        // Non-shared user should see no resources
+        TestRestClient.HttpResponse response = ok(() -> api.searchResources(FULL_ACCESS_USER));
+        assertThat(response.getBody(), containsString("\"hits\":{\"total\":{\"value\":0"));
+    }
+}

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DlsAliasSearchTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DlsAliasSearchTests.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource.feature.enabled;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.sample.resource.TestUtils;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.newCluster;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
+
+/**
+ * Tests that DLS (Document Level Security) is correctly applied when searching
+ * a resource index via an alias through the PluginClient.
+ *
+ * Regression test for: DLS filter not applied when alias name differs from concrete index name.
+ * The DLS restriction map must include both concrete index names and alias names so that
+ * DlsFilterLevelActionHandler.modifyQuery() can find the restriction regardless of which
+ * name is used for iteration.
+ */
+@RunWith(RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class DlsAliasSearchTests {
+
+    private static final String RESOURCE_INDEX_ALIAS = ".sample_resource_alias";
+
+    @ClassRule
+    public static LocalCluster cluster = newCluster(true, true);
+
+    private final TestUtils.ApiHelper api = new TestUtils.ApiHelper(cluster);
+    private String adminResourceId;
+    private String userResourceId;
+
+    @Before
+    public void setup() {
+        // Create resources as two different users
+        adminResourceId = api.createSampleResourceAs(USER_ADMIN);
+        api.awaitSharingEntry(adminResourceId);
+
+        userResourceId = api.createSampleResourceAs(FULL_ACCESS_USER);
+        api.awaitSharingEntry(userResourceId, FULL_ACCESS_USER.getName());
+
+        // Create an alias for the resource index
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            String aliasPayload = """
+                {
+                  "actions": [
+                    { "add": { "index": "%s", "alias": "%s" } }
+                  ]
+                }
+                """.formatted(RESOURCE_INDEX_NAME, RESOURCE_INDEX_ALIAS);
+            TestRestClient.HttpResponse response = client.postJson("_aliases", aliasPayload);
+            response.assertStatusCode(HttpStatus.SC_OK);
+        }
+    }
+
+    @After
+    public void cleanup() {
+        // Remove alias
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            String aliasPayload = """
+                {
+                  "actions": [
+                    { "remove": { "index": "%s", "alias": "%s" } }
+                  ]
+                }
+                """.formatted(RESOURCE_INDEX_NAME, RESOURCE_INDEX_ALIAS);
+            client.postJson("_aliases", aliasPayload);
+        }
+        api.wipeOutResourceEntries();
+    }
+
+    @Test
+    public void searchViaAlias_shouldApplyDls_userSeesOnlyOwnResources() {
+        // Search via concrete index name — DLS should filter to only user's own resources
+        TestRestClient.HttpResponse directResponse = api.searchResources(FULL_ACCESS_USER);
+        directResponse.assertStatusCode(HttpStatus.SC_OK);
+        int directHits = getHitCount(directResponse);
+
+        // Search via alias — DLS should also be applied, returning the same results
+        TestRestClient.HttpResponse aliasResponse = api.searchResourcesByAlias(RESOURCE_INDEX_ALIAS, FULL_ACCESS_USER);
+        aliasResponse.assertStatusCode(HttpStatus.SC_OK);
+        int aliasHits = getHitCount(aliasResponse);
+
+        // Both searches should return the same number of hits (DLS applied in both cases)
+        assert directHits == aliasHits : "DLS not applied when searching via alias: direct=" + directHits + " alias=" + aliasHits;
+    }
+
+    @SuppressWarnings("unchecked")
+    private int getHitCount(TestRestClient.HttpResponse response) {
+        java.util.Map<String, Object> hits = (java.util.Map<String, Object>) response.bodyAsMap().get("hits");
+        return ((java.util.List<?>) hits.get("hits")).size();
+    }
+}

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceExtension.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceExtension.java
@@ -20,6 +20,7 @@ import org.opensearch.security.spi.resources.client.ResourceSharingClient;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_GROUP_TYPE;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_PATTERN;
 import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 
 /**
@@ -37,7 +38,13 @@ public class SampleResourceExtension implements ResourceSharingExtension {
 
             @Override
             public String resourceIndexName() {
-                return RESOURCE_INDEX_NAME;
+                return SampleResourcePlugin.aliasMode ? RESOURCE_INDEX_PATTERN : RESOURCE_INDEX_NAME;
+            }
+
+            @Override
+            public String resourceSharingIndexName() {
+                // Always use the same sharing index name regardless of mode
+                return RESOURCE_INDEX_NAME + "-sharing";
             }
 
             @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourcePlugin.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourcePlugin.java
@@ -20,6 +20,7 @@ import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.core.action.ActionResponse;
@@ -74,6 +75,7 @@ import org.opensearch.transport.client.Client;
 import org.opensearch.watcher.ResourceWatcherService;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_PATTERN;
 
 /**
  * Sample Resource plugin.
@@ -82,6 +84,16 @@ import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
  */
 public class SampleResourcePlugin extends Plugin implements ActionPlugin, SystemIndexPlugin, IdentityAwarePlugin {
     private PluginClient pluginClient;
+
+    /** When true, the plugin uses an alias (.sample_resource) over a concrete index (.sample_resource_1) with a wildcard pattern. */
+    static volatile boolean aliasMode = false;
+
+    public static final String ALIAS_MODE_SETTING_KEY = "sample_resource.alias_mode";
+    public static final Setting<Boolean> ALIAS_MODE_SETTING = Setting.boolSetting(
+        ALIAS_MODE_SETTING_KEY,
+        false,
+        Setting.Property.NodeScope
+    );
 
     public SampleResourcePlugin() {}
 
@@ -100,6 +112,7 @@ public class SampleResourcePlugin extends Plugin implements ActionPlugin, System
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         this.pluginClient = new PluginClient(client);
+        aliasMode = environment.settings().getAsBoolean(ALIAS_MODE_SETTING_KEY, false);
 
         return List.of(pluginClient);
     }
@@ -147,8 +160,13 @@ public class SampleResourcePlugin extends Plugin implements ActionPlugin, System
 
     @Override
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
-        final SystemIndexDescriptor systemIndexDescriptor = new SystemIndexDescriptor(RESOURCE_INDEX_NAME, "Sample index with resources");
-        return Collections.singletonList(systemIndexDescriptor);
+        String indexName = settings.getAsBoolean(ALIAS_MODE_SETTING_KEY, false) ? RESOURCE_INDEX_PATTERN : RESOURCE_INDEX_NAME;
+        return Collections.singletonList(new SystemIndexDescriptor(indexName, "Sample index with resources"));
+    }
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(ALIAS_MODE_SETTING);
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/search/SearchResourceRestAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/search/SearchResourceRestAction.java
@@ -58,7 +58,8 @@ public class SearchResourceRestAction extends BaseRestHandler {
             searchSourceBuilder.query(QueryBuilders.matchAllQuery());
         }
 
-        SearchRequest searchRequest = new SearchRequest().indices(RESOURCE_INDEX_NAME).source(searchSourceBuilder);
+        String index = request.param("index", RESOURCE_INDEX_NAME);
+        SearchRequest searchRequest = new SearchRequest().indices(index).source(searchSourceBuilder);
 
         return channel -> client.executeLocally(SearchResourceAction.INSTANCE, searchRequest, new RestToXContentListener<>(channel));
     }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/utils/Constants.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/utils/Constants.java
@@ -13,6 +13,8 @@ package org.opensearch.sample.utils;
  */
 public class Constants {
     public static final String RESOURCE_INDEX_NAME = ".sample_resource";
+    public static final String RESOURCE_INDEX_PATTERN = ".sample_resource_*";
+    public static final String RESOURCE_INDEX_CONCRETE = ".sample_resource_1";
     public static final String RESOURCE_TYPE = "sample-resource";
     public static final String RESOURCE_GROUP_TYPE = "sample-resource-group";
 

--- a/spi/src/main/java/org/opensearch/security/spi/resources/ResourceProvider.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/ResourceProvider.java
@@ -21,6 +21,17 @@ public interface ResourceProvider {
     String resourceIndexName();
 
     /**
+     * Returns the name of the sharing index for this resource type.
+     * For plugins using wildcard index patterns (e.g. {@code .kibana*}),
+     * this must return a concrete index name (e.g. {@code .kibana-sharing}).
+     *
+     * @return the sharing index name, defaults to {@code resourceIndexName() + "-sharing"}
+     */
+    default String resourceSharingIndexName() {
+        return resourceIndexName() + "-sharing";
+    }
+
+    /**
      * Returns the name of the field representing the resource type in the resource document.
      *
      * @return the field name containing the resource type

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -248,7 +248,6 @@ import static org.opensearch.http.HttpTransportSettings.SETTING_HTTP_HTTP3_ENABL
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.ENDPOINTS_WITH_PERMISSIONS;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.SECURITY_CONFIG_UPDATE;
 import static org.opensearch.security.privileges.dlsfls.FieldMasking.Config.BLAKE2B_LEGACY_DEFAULT;
-import static org.opensearch.security.resources.ResourceSharingIndexHandler.getSharingIndex;
 import static org.opensearch.security.setting.DeprecatedSettings.checkForDeprecatedSetting;
 import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX;
@@ -789,7 +788,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 resourceSharingEnabledSetting
             );
             Set<String> resourceIndices = resourcePluginInfo.getResourceIndices();
-            if (resourceIndices.contains(indexModule.getIndex().getName())) {
+            if (resourcePluginInfo.isResourceIndex(indexModule.getIndex().getName())) {
                 indexModule.addIndexOperationListener(resourceIndexListener);
                 log.info("Security plugin started listening to operations on resource-index {}", indexModule.getIndex().getName());
             }
@@ -2351,11 +2350,11 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             // create resource sharing index if absent
             // TODO check if this should be wrapped in an atomic completable future
             log.debug("Attempting to create Resource Sharing index");
-            Set<String> resourceIndices = new HashSet<>();
+            Set<String> sharingIndices = new HashSet<>();
             if (resourcePluginInfo != null) {
-                resourceIndices = resourcePluginInfo.getResourceIndices();
+                sharingIndices = resourcePluginInfo.getResourceSharingIndices();
             }
-            rsIndexHandler.createResourceSharingIndicesIfAbsent(resourceIndices);
+            rsIndexHandler.createResourceSharingIndicesIfAbsent(sharingIndices);
 
         }
 
@@ -2423,10 +2422,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         final SystemIndexDescriptor securityIndexDescriptor = new SystemIndexDescriptor(indexPattern, "Security index");
         systemIndexDescriptors.add(securityIndexDescriptor);
 
-        for (String resourceIndex : resourcePluginInfo.getResourceIndices()) {
+        for (String sharingIndex : resourcePluginInfo.getResourceSharingIndices()) {
             final SystemIndexDescriptor resourceSharingIndexDescriptor = new SystemIndexDescriptor(
-                getSharingIndex(resourceIndex),
-                "Resource Sharing index for index: " + resourceIndex
+                sharingIndex,
+                "Resource Sharing index: " + sharingIndex
             );
             systemIndexDescriptors.add(resourceSharingIndexDescriptor);
         }

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -13,6 +13,7 @@ package org.opensearch.security.configuration;
 
 import java.lang.reflect.Field;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -184,9 +185,11 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                 WildcardMatcher resourceIndicesMatcher = WildcardMatcher.from(protectedIndices);
                 Set<String> resolvedIndexNames = resolvedIndices.local().namesOfIndices(context.clusterState());
                 if (resourceIndicesMatcher.matchAll(resolvedIndexNames)) {
+                    Set<String> allIndexNames = new HashSet<>(resolvedIndexNames);
+                    allIndexNames.addAll(resolvedIndices.local().names(context.clusterState()));
                     IndexToRuleMap<DlsRestriction> sharedResourceMap = ResourceSharingDlsUtils.resourceRestrictions(
                         namedXContentRegistry,
-                        resolvedIndexNames,
+                        allIndexNames,
                         userSubject.getUser()
                     );
 

--- a/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
@@ -125,7 +125,7 @@ public class ResourceAccessEvaluator {
             return false;
         }
         // if requested index is not a resource sharing index, move on to the regular evaluator
-        if (!resourcePluginInfo.getResourceIndicesForProtectedTypes().contains(docRequest.index())) {
+        if (!resourcePluginInfo.isProtectedResourceIndex(docRequest.index())) {
             log.debug("Request index {} is not a protected resource index", docRequest.index());
             return false;
         }

--- a/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
@@ -67,7 +67,7 @@ public class ResourceIndexListener implements IndexingOperationListener {
         }
         String resourceIndex = shardId.getIndexName();
 
-        if (!resourcePluginInfo.getResourceIndicesForProtectedTypes().contains(resourceIndex)) {
+        if (!resourcePluginInfo.isProtectedResourceIndex(resourceIndex)) {
             // type is marked as not protected
             return;
         }
@@ -149,7 +149,7 @@ public class ResourceIndexListener implements IndexingOperationListener {
         }
         String resourceIndex = shardId.getIndexName();
 
-        if (!resourcePluginInfo.getResourceIndicesForProtectedTypes().contains(resourceIndex)) {
+        if (!resourcePluginInfo.isProtectedResourceIndex(resourceIndex)) {
             // type is marked as not protected
             return;
         }

--- a/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
+++ b/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
@@ -33,6 +33,7 @@ import org.opensearch.security.setting.OpensearchDynamicSetting;
 import org.opensearch.security.spi.resources.ResourceProvider;
 import org.opensearch.security.spi.resources.ResourceSharingExtension;
 import org.opensearch.security.spi.resources.client.ResourceSharingClient;
+import org.opensearch.security.support.WildcardMatcher;
 
 /**
  * This class provides information about resource plugins and their associated resource providers and indices.
@@ -170,7 +171,7 @@ public class ResourcePluginInfo {
             // If typeField is not present, assume single resource type per index and return type from provider
             var provider = typeToProvider.values()
                 .stream()
-                .filter(p -> p.resourceIndexName().equals(resourceIndex))
+                .filter(p -> WildcardMatcher.from(p.resourceIndexName()).test(resourceIndex))
                 .findFirst()
                 .orElse(null);
             if (provider == null) {
@@ -315,6 +316,71 @@ public class ResourcePluginInfo {
         lock.readLock().lock();
         try {
             return typeToProvider.values().stream().map(ResourceProvider::resourceIndexName).collect(Collectors.toSet());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Checks whether a concrete index name matches any registered resource index pattern.
+     */
+    public boolean isResourceIndex(String concreteIndexName) {
+        lock.readLock().lock();
+        try {
+            return WildcardMatcher.from(
+                typeToProvider.values().stream().map(ResourceProvider::resourceIndexName).collect(Collectors.toSet())
+            ).test(concreteIndexName);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Checks whether a concrete index name matches any protected resource index pattern.
+     */
+    public boolean isProtectedResourceIndex(String concreteIndexName) {
+        return WildcardMatcher.from(getResourceIndicesForProtectedTypes()).test(concreteIndexName);
+    }
+
+    /**
+     * Returns the sharing index name for the given resource type.
+     */
+    public String sharingIndexByType(String type) {
+        lock.readLock().lock();
+        try {
+            if (!typeToProvider.containsKey(type)) {
+                return null;
+            }
+            return typeToProvider.get(type).resourceSharingIndexName();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Returns the sharing index name for a concrete resource index name by finding the matching provider.
+     */
+    public String sharingIndexForResourceIndex(String concreteResourceIndex) {
+        lock.readLock().lock();
+        try {
+            for (ResourceProvider p : typeToProvider.values()) {
+                if (WildcardMatcher.from(p.resourceIndexName()).test(concreteResourceIndex)) {
+                    return p.resourceSharingIndexName();
+                }
+            }
+            return null;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Returns the set of all sharing index names for registered resource types.
+     */
+    public Set<String> getResourceSharingIndices() {
+        lock.readLock().lock();
+        try {
+            return typeToProvider.values().stream().map(ResourceProvider::resourceSharingIndexName).collect(Collectors.toSet());
         } finally {
             lock.readLock().unlock();
         }

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -124,11 +124,10 @@ public class ResourceSharingIndexHandler {
      *                          or communicating with the cluster
      */
 
-    public void createResourceSharingIndicesIfAbsent(Collection<String> resourceIndices) {
+    public void createResourceSharingIndicesIfAbsent(Collection<String> sharingIndices) {
         // TODO: Once stashContext is replaced with switchContext this call will have to be modified
         try (ThreadContext.StoredContext ctx = this.threadPool.getThreadContext().stashContext()) {
-            for (String resourceIndex : resourceIndices) {
-                String resourceSharingIndex = getSharingIndex(resourceIndex);
+            for (String resourceSharingIndex : sharingIndices) {
                 CreateIndexRequest cir = new CreateIndexRequest(resourceSharingIndex).settings(INDEX_SETTINGS).waitForActiveShards(1);
                 ActionListener<CreateIndexResponse> cirListener = ActionListener.wrap(response -> {
                     ctx.restore();
@@ -144,6 +143,15 @@ public class ResourceSharingIndexHandler {
 
     public static String getSharingIndex(String resourceIndex) {
         return resourceIndex + "-sharing";
+    }
+
+    /**
+     * Resolves the sharing index for a concrete resource index name using the registered providers.
+     * Falls back to the static {@link #getSharingIndex(String)} convention if no provider matches.
+     */
+    String resolveSharingIndex(String resourceIndex) {
+        String resolved = resourcePluginInfo.sharingIndexForResourceIndex(resourceIndex);
+        return resolved != null ? resolved : getSharingIndex(resourceIndex);
     }
 
     /**
@@ -251,7 +259,7 @@ public class ResourceSharingIndexHandler {
         String resourceId = sharingInfo.getResourceId();
         CreatedBy createdBy = sharingInfo.getCreatedBy();
         // TODO: Once stashContext is replaced with switchContext this call will have to be modified
-        String resourceSharingIndex = getSharingIndex(resourceIndex);
+        String resourceSharingIndex = resolveSharingIndex(resourceIndex);
         try (ThreadContext.StoredContext ctx = this.threadPool.getThreadContext().stashContext()) {
             IndexRequest ir = client.prepareIndex(resourceSharingIndex)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
@@ -329,7 +337,7 @@ public class ResourceSharingIndexHandler {
      * </ul>
      */
     public void fetchAllResourceIds(String resourceIndex, ActionListener<Set<String>> listener) {
-        String resourceSharingIndex = getSharingIndex(resourceIndex);
+        String resourceSharingIndex = resolveSharingIndex(resourceIndex);
         LOGGER.debug("Fetching all documents asynchronously from {}", resourceSharingIndex);
         Scroll scroll = new Scroll(TimeValue.timeValueMinutes(1L));
 
@@ -357,7 +365,7 @@ public class ResourceSharingIndexHandler {
      * @param listener to collect and return the sharing records
      */
     public void fetchAllResourceSharingRecords(String resourceIndex, String resourceType, ActionListener<Set<SharingRecord>> listener) {
-        String resourceSharingIndex = getSharingIndex(resourceIndex);
+        String resourceSharingIndex = resolveSharingIndex(resourceIndex);
         LOGGER.debug("Fetching all resource-sharing records asynchronously from {}", resourceSharingIndex);
         Scroll scroll = new Scroll(TimeValue.timeValueMinutes(1L));
 
@@ -554,7 +562,7 @@ public class ResourceSharingIndexHandler {
             listener.onFailure(new IllegalArgumentException("resourceIndex and resourceId must not be null or empty"));
             return;
         }
-        String resourceSharingIndex = getSharingIndex(resourceIndex);
+        String resourceSharingIndex = resolveSharingIndex(resourceIndex);
         LOGGER.debug("Fetching document from {}, matching resource_id: {}", resourceSharingIndex, resourceId);
 
         try (ThreadContext.StoredContext ctx = this.threadPool.getThreadContext().stashContext()) {
@@ -653,7 +661,7 @@ public class ResourceSharingIndexHandler {
                 sharingInfo.share(accessLevel, target);
             }
 
-            String resourceSharingIndex = getSharingIndex(resourceIndex);
+            String resourceSharingIndex = resolveSharingIndex(resourceIndex);
             try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
                 IndexRequest ir = client.prepareIndex(resourceSharingIndex)
                     .setId(sharingInfo.getResourceId())
@@ -711,7 +719,7 @@ public class ResourceSharingIndexHandler {
     ) {
 
         StepListener<ResourceSharing> sharingInfoListener = new StepListener<>();
-        String resourceSharingIndex = getSharingIndex(resourceIndex);
+        String resourceSharingIndex = resolveSharingIndex(resourceIndex);
 
         // Fetch the current ResourceSharing document
         fetchSharingInfo(resourceIndex, resourceId, sharingInfoListener);
@@ -807,7 +815,7 @@ public class ResourceSharingIndexHandler {
      * </pre>
      */
     public void deleteResourceSharingRecord(String resourceId, String resourceIndex, ActionListener<Boolean> listener) {
-        String resourceSharingIndex = getSharingIndex(resourceIndex);
+        String resourceSharingIndex = resolveSharingIndex(resourceIndex);
         LOGGER.debug(
             "Deleting documents asynchronously from {} where source_idx = {} and resource_id = {}",
             resourceSharingIndex,
@@ -943,7 +951,7 @@ public class ResourceSharingIndexHandler {
         Set<String> flatPrincipals,
         ActionListener<Set<SharingRecord>> listener
     ) {
-        final String resourceSharingIndex = getSharingIndex(resourceIndex);
+        final String resourceSharingIndex = resolveSharingIndex(resourceIndex);
         final ThreadContext.StoredContext stored = this.threadPool.getThreadContext().stashContext();
 
         // Phase 1: resolve resource IDs from the RESOURCE index

--- a/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
@@ -62,6 +62,7 @@ import org.opensearch.security.resources.sharing.ResourceSharing;
 import org.opensearch.security.resources.sharing.ShareWith;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.spi.resources.ResourceProvider;
+import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -257,7 +258,7 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
                         // no type field and no explicit access level map — infer from the single registered type for this index
                         type = resourcePluginInfo.currentProtectedTypes()
                             .stream()
-                            .filter(t -> sourceIndex.equals(resourcePluginInfo.indexByType(t)))
+                            .filter(t -> WildcardMatcher.from(resourcePluginInfo.indexByType(t)).test(sourceIndex))
                             .findFirst()
                             .orElse(null);
                     }
@@ -481,13 +482,9 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
                         Set<String> allowedIndices = resourcePluginInfo.getResourceIndicesForProtectedTypes();
                         RequestContentValidator.FieldValidator sourceIndexValidator = (fieldName, value) -> {
                             if (value instanceof String strValue) {
-                                RequestContentValidator.validateFieldValueInSet(
-                                    fieldName,
-                                    strValue,
-                                    RequestContentValidator.MAX_STRING_LENGTH,
-                                    allowedIndices,
-                                    "indices"
-                                );
+                                if (!WildcardMatcher.from(allowedIndices).test(strValue)) {
+                                    throw new IllegalArgumentException(fieldName + " " + strValue + " is not a recognized resource index");
+                                }
                             }
                         };
 


### PR DESCRIPTION
  ### Description

  Resource sharing currently assumes each plugin registers a single concrete index name (e.g. `.opensearch-docs`). OpenSearch Dashboards uses `.kibana` as an alias that maps to enumerated concrete indices like `.kibana_1`, `.kibana_2`, etc. This PR adds support for wildcard index patterns (e.g. `.kibana_*`) so that resource sharing works correctly when the resource index is behind an alias.

  ### Changes

  **SPI:**
  - No new methods. The sharing index name is derived by convention from the index/alias the plugin writes to.

  **Core framework:**
  - `ResourcePluginInfo` — Added `isResourceIndex()` and `isProtectedResourceIndex()` using `WildcardMatcher` instead of `Set.contains()`. Changed `getResourceTypeForIndexOp()` to use wildcard matching.
  - `ResourceSharingIndexHandler` — Added `resolveSharingIndex()` with `resolveWriteTarget()` that resolves concrete index → alias via `ClusterService`, or strips the wildcard from patterns. Sharing index name = write target +
  `-sharing`. Added `ensureSharingIndexExists()` for lazy async creation on first write. Startup creation preserved for non-wildcard indices.
  - `ResourceIndexListener` — `postIndex`/`postDelete` use `isProtectedResourceIndex()` wildcard match. Added `setClusterService()` for deferred injection (handles indices created after startup).
  - `ResourceAccessEvaluator` — `shouldEvaluate()` uses `isProtectedResourceIndex()` wildcard match.
  - `OpenSearchSecurityPlugin` — `onIndexModule` uses wildcard matching for listener attachment; injects `ClusterService` into listeners; startup sharing index creation skips wildcard patterns (handled lazily instead).
  - `MigrateResourceSharingInfoApiAction` — Source index validation and type inference use `WildcardMatcher`.

  **DLS fix (related):**
  - `DlsFlsValveImpl` — Include alias names in the DLS restriction map so that DLS filtering works when searching via an alias.
  - `SearchResourceRestAction` — Accept `?index=` parameter to allow searching via alias name.

  **Sample plugin (testing support):**
  - Added `sample_resource.alias_mode` setting that toggles between concrete index mode (`.sample_resource`) and alias+pattern mode (`.sample_resource` alias → `.sample_resource_1` concrete index, pattern `.sample_resource_*`).

  ### Testing

  - `AliasIndexPatternTests` — 10 integration tests running in alias mode covering: owner CRUD, full-access sharing/revoke, read-only access for all user types, mixed access level upgrades, and DLS filtering through alias.
  - `DlsAliasSearchTests` — Integration test validating DLS filtering works when searching via alias name.
  - All existing tests (FullAccessTests, ReadOnlyAccessTests, MixedAccessTests, unit tests) continue to pass in normal mode.

  ### Key design decisions

  1. `resourceIndexName()` can now return a wildcard pattern (e.g. `.kibana_*`). All exact-match checks replaced with `WildcardMatcher`.
  2. Sharing index name derived by convention — no SPI method needed. The framework resolves the write target (alias or base name from the pattern) and appends `-sharing`. For concrete indices, the alias is resolved via
  `ClusterService`. For patterns, the wildcard and trailing separator are stripped.
  3. Sharing index created lazily on first write for alias-mode plugins. Startup creation preserved for non-wildcard indices to avoid system index protection issues.
  4. The plugin's own system index pattern (e.g. `.kibana_*`) covers the sharing index (e.g. `.kibana-sharing`) automatically — no separate system index registration needed.
  5. `ClusterService` is injected into `ResourceIndexListener` handlers via deferred `setClusterService()` since `onIndexModule` runs before `createComponents`, and indices may also be created at runtime.

  ### Check List
  - [x] New functionality includes testing
  - [x] New functionality has been documented
  - [x] Commits are signed per the DCO using `--signoff`