### PR TITLE
Add new setting for standby_mode to allow replicating security configuration (system) indices

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/StandbyModeCcrSimulationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/StandbyModeCcrSimulationTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.TestSecurityConfig.User;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.ContextHeaderDecoratorClient;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+import org.opensearch.transport.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+
+/**
+ * Tests standby mode behavior simulating a CCR follower cluster.
+ *
+ * The "leader" cluster has a normal security configuration.
+ * The "standby" cluster starts with standby_mode=true and loadConfigurationIntoIndex=false,
+ * meaning it does NOT bootstrap its own security index. Instead, we manually write security
+ * config to its security index (simulating what CCR replication would do), and verify that:
+ *
+ * 1. The standby cluster picks up the replicated config via polling
+ * 2. Authentication works using the replicated config
+ * 3. Config mutation APIs are blocked
+ */
+public class StandbyModeCcrSimulationTests {
+
+    private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+
+    private static final Role READONLY_ROLE = new Role("readonly_role").clusterPermissions("cluster_monitor")
+        .indexPermissions("indices:data/read/*")
+        .on("*");
+
+    private static final User READONLY_USER = new User("readonly_user").roles(READONLY_ROLE);
+
+    /**
+     * Leader cluster — normal active cluster with security config
+     */
+    @ClassRule
+    public static final LocalCluster leaderCluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .clusterName("leader")
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, READONLY_USER)
+        .roles(READONLY_ROLE)
+        .nodeSettings(Map.of(SECURITY_RESTAPI_ROLES_ENABLED, List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName())))
+        .build();
+
+    /**
+     * Standby cluster — starts in standby mode with NO security index.
+     * Security config will be "replicated" (manually written) from the leader.
+     */
+    @ClassRule
+    public static final LocalCluster standbyCluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .clusterName("standby")
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, READONLY_USER)
+        .roles(READONLY_ROLE)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(
+            Map.of(
+                SECURITY_RESTAPI_ROLES_ENABLED,
+                List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName()),
+                ConfigConstants.SECURITY_STANDBY_MODE,
+                true,
+                ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX,
+                false
+            )
+        )
+        .build();
+
+    /**
+     * Simulate CCR replication: copy security config from leader to standby.
+     * In a real setup, CCR would replicate the .opendistro_security index.
+     * Here we manually create the index and write the config documents.
+     */
+    @BeforeClass
+    public static void simulateCcrReplication() throws Exception {
+        // Read config from leader and write it to standby's security index
+        try (
+            Client standbyClient = new ContextHeaderDecoratorClient(
+                standbyCluster.getInternalNodeClient(),
+                Map.of(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true")
+            )
+        ) {
+            // Create the security index on standby (CCR would do this)
+            standbyClient.admin()
+                .indices()
+                .create(
+                    new CreateIndexRequest(ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX).settings(
+                        Map.of("index.number_of_shards", 1, "index.auto_expand_replicas", "0-all", "index.hidden", true)
+                    )
+                )
+                .actionGet();
+
+            // Copy each config type from leader to standby
+            try (
+                Client leaderClient = new ContextHeaderDecoratorClient(
+                    leaderCluster.getInternalNodeClient(),
+                    Map.of(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true")
+                )
+            ) {
+                for (String configType : CType.lcStringValues()) {
+                    var getResponse = leaderClient.prepareGet(ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX, configType).get();
+
+                    if (getResponse.isExists()) {
+                        standbyClient.prepareIndex(ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX)
+                            .setId(configType)
+                            .setSource(getResponse.getSourceAsMap())
+                            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                            .get();
+                    }
+                }
+            }
+        }
+
+        // Wait for the standby's config polling to pick up the replicated config
+        Thread.sleep(10_000);
+    }
+
+    @Test
+    public void testAuthenticationWorksOnStandbyWithReplicatedConfig() {
+        try (TestRestClient client = standbyCluster.getRestClient(ADMIN_USER)) {
+            HttpResponse response = client.get("_cluster/health");
+            assertThat(response.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        }
+    }
+
+    @Test
+    public void testConfigMutationBlockedOnStandby() {
+        try (TestRestClient client = standbyCluster.getRestClient(ADMIN_USER)) {
+            HttpResponse response = client.putJson(
+                "_plugins/_security/api/roles/new_role",
+                "{\"cluster_permissions\": [\"cluster_monitor\"]}"
+            );
+            assertThat(response.getStatusCode(), equalTo(RestStatus.FORBIDDEN.getStatus()));
+            assertThat(response.getBody(), containsString("standby mode"));
+        }
+    }
+
+    @Test
+    public void testConfigReadAllowedOnStandby() {
+        try (TestRestClient client = standbyCluster.getRestClient(ADMIN_USER)) {
+            HttpResponse response = client.get("_plugins/_security/api/roles");
+            assertThat(response.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        }
+    }
+
+    @Test
+    public void testLeaderClusterOperatesNormally() {
+        try (TestRestClient client = leaderCluster.getRestClient(ADMIN_USER)) {
+            // Leader should allow config mutations
+            HttpResponse response = client.putJson(
+                "_plugins/_security/api/roles/leader_test_role",
+                "{\"cluster_permissions\": [\"cluster_monitor\"]}"
+            );
+            assertThat(response.getStatusCode(), equalTo(RestStatus.CREATED.getStatus()));
+
+            // Clean up
+            client.delete("_plugins/_security/api/roles/leader_test_role");
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/StandbyModeTests.java
+++ b/src/integrationTest/java/org/opensearch/security/StandbyModeTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.TestSecurityConfig.AuthcDomain;
+import org.opensearch.test.framework.TestSecurityConfig.User;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+
+public class StandbyModeTests {
+
+    public static final AuthcDomain AUTHC_DOMAIN = new AuthcDomain("basic", 0).httpAuthenticatorWithChallenge("basic").backend("internal");
+
+    private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(AUTHC_DOMAIN)
+        .users(ADMIN_USER)
+        .nodeSettings(
+            Map.of(
+                SECURITY_RESTAPI_ROLES_ENABLED,
+                List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName()),
+                ConfigConstants.SECURITY_STANDBY_MODE,
+                true
+            )
+        )
+        .build();
+
+    @Test
+    public void testAuthenticationWorksInStandbyMode() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            HttpResponse response = client.get("_cluster/health");
+            assertThat(response.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        }
+    }
+
+    @Test
+    public void testSecurityConfigMutationBlockedInStandbyMode() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            // Try to create a role — should be blocked
+            HttpResponse response = client.putJson(
+                "_plugins/_security/api/roles/test_role",
+                "{\"cluster_permissions\": [\"cluster_monitor\"]}"
+            );
+            assertThat(response.getStatusCode(), equalTo(RestStatus.FORBIDDEN.getStatus()));
+            assertThat(response.getBody(), containsString("standby mode"));
+        }
+    }
+
+    @Test
+    public void testSecurityConfigReadAllowedInStandbyMode() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            // Reading roles should still work
+            HttpResponse response = client.get("_plugins/_security/api/roles");
+            assertThat(response.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+        }
+    }
+
+    @Test
+    public void testInternalUsersApiBlockedInStandbyMode() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            HttpResponse response = client.putJson(
+                "_plugins/_security/api/internalusers/new_user",
+                "{\"password\": \"testPassword123!\", \"backend_roles\": [\"admin\"]}"
+            );
+            assertThat(response.getStatusCode(), equalTo(RestStatus.FORBIDDEN.getStatus()));
+            assertThat(response.getBody(), containsString("standby mode"));
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImplTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImplTest.java
@@ -45,6 +45,7 @@ import org.opensearch.security.securityconf.FlattenedActionGroups;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
+import org.opensearch.security.setting.StandbyModeSetting;
 import org.opensearch.security.user.User;
 import org.opensearch.test.framework.log.LogsRule;
 
@@ -280,7 +281,8 @@ public class PrivilegesEvaluatorImplTest {
                 settings,
                 indexNameExpressionResolver,
                 () -> "unavailable",
-                NamedXContentRegistry.EMPTY
+                NamedXContentRegistry.EMPTY,
+                new StandbyModeSetting(settings)
             ),
             dynamicDependencies.with(compiledRoles)
         );

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1377,7 +1377,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         final var allowDefaultInit = settings.getAsBoolean(SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, false);
         final var useClusterState = useClusterStateToInitSecurityConfig(settings);
-        if (!SSLConfig.isSslOnlyMode() && !isDisabled(settings) && allowDefaultInit && useClusterState) {
+        final var standbyMode = settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false);
+        if (!SSLConfig.isSslOnlyMode() && !isDisabled(settings) && ((allowDefaultInit && useClusterState) || standbyMode)) {
             clusterService.addListener(cr);
         }
 
@@ -1626,6 +1627,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             );
 
             settings.add(Setting.boolSetting(ConfigConstants.SECURITY_DISABLED, false, Property.NodeScope, Property.Filtered));
+
+            settings.add(
+                Setting.boolSetting(ConfigConstants.SECURITY_STANDBY_MODE, false, Property.NodeScope, Property.Dynamic, Property.Sensitive)
+            );
 
             settings.add(SecuritySettings.CACHE_TTL_SETTING);
 

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -203,6 +203,7 @@ import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.setting.OpensearchDynamicSetting;
+import org.opensearch.security.setting.StandbyModeSetting;
 import org.opensearch.security.setting.TransportPassiveAuthSetting;
 import org.opensearch.security.spi.SecurityConfigExtension;
 import org.opensearch.security.spi.resources.ResourceSharingExtension;
@@ -297,6 +298,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     private final AtomicReference<NamedXContentRegistry> namedXContentRegistry = new AtomicReference<>(NamedXContentRegistry.EMPTY);;
     private volatile DlsFlsRequestValve dlsFlsValve = null;
     private final OpensearchDynamicSetting<Boolean> transportPassiveAuthSetting;
+    private final OpensearchDynamicSetting<Boolean> standbyModeSetting;
     private final OpensearchDynamicSetting<Boolean> resourceSharingEnabledSetting;
     private final OpensearchDynamicSetting<List<String>> resourceSharingProtectedResourceTypesSetting;
     private volatile PasswordHasher passwordHasher;
@@ -365,6 +367,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         // dynamic settings
         transportPassiveAuthSetting = new TransportPassiveAuthSetting(settings);
+        standbyModeSetting = new StandbyModeSetting(settings);
         resourceSharingEnabledSetting = new ResourceSharingFeatureFlagSetting(settings, resourcePluginInfo); // not filtered
         resourceSharingProtectedResourceTypesSetting = new ResourceSharingProtectedResourcesSetting(settings, resourcePluginInfo); // not
                                                                                                                                    // filtered
@@ -707,7 +710,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                         sslCertReloadEnabled,
                         passwordHasher,
                         rsIndexHandler,
-                        resourcePluginInfo
+                        resourcePluginInfo,
+                        standbyModeSetting
                     )
                 );
 
@@ -1163,6 +1167,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         // Register opensearch dynamic settings
         transportPassiveAuthSetting.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
+        standbyModeSetting.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
         resourceSharingEnabledSetting.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
         resourceSharingProtectedResourceTypesSetting.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
 
@@ -1195,7 +1200,15 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         adminDns = new AdminDNs(settings);
 
-        cr = ConfigurationRepository.create(settings, this.configPath, threadPool, localClient, clusterService, auditLog);
+        cr = ConfigurationRepository.create(
+            settings,
+            this.configPath,
+            threadPool,
+            localClient,
+            clusterService,
+            auditLog,
+            standbyModeSetting
+        );
 
         this.passwordHasher = PasswordHasherFactory.createPasswordHasher(settings);
 
@@ -1230,7 +1243,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 settings,
                 resolver,
                 cih::getReasonForUnavailability,
-                xContentRegistry
+                xContentRegistry,
+                standbyModeSetting
             )
         );
         this.privilegesConfiguration = privilegesConfiguration;
@@ -1286,7 +1300,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             cs,
             compatConfig,
             xffResolver,
-            resourceAccessEvaluator
+            resourceAccessEvaluator,
+            standbyModeSetting
         );
 
         final String principalExtractorClass = settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_PRINCIPAL_EXTRACTOR_CLASS, null);
@@ -1628,9 +1643,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
             settings.add(Setting.boolSetting(ConfigConstants.SECURITY_DISABLED, false, Property.NodeScope, Property.Filtered));
 
-            settings.add(
-                Setting.boolSetting(ConfigConstants.SECURITY_STANDBY_MODE, false, Property.NodeScope, Property.Dynamic, Property.Sensitive)
-            );
+            settings.add(StandbyModeSetting.STANDBY_MODE);
 
             settings.add(SecuritySettings.CACHE_TTL_SETTING);
 

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -89,6 +89,8 @@ import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
+import org.opensearch.security.setting.StandbyModeSetting;
 import org.opensearch.security.ssl.util.ExceptionUtils;
 import org.opensearch.security.state.SecurityMetadata;
 import org.opensearch.security.support.ConfigConstants;
@@ -128,6 +130,8 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
 
     private final ReloadThread reloadThread;
 
+    private final OpensearchDynamicSetting<Boolean> standbyModeSetting;
+
     private volatile Cancellable configPollingTask;
 
     // visible for testing
@@ -142,6 +146,33 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
         final SecurityIndexHandler securityIndexHandler,
         final ConfigurationLoaderSecurity7 configurationLoaderSecurity7
     ) {
+        this(
+            securityIndex,
+            settings,
+            configPath,
+            threadPool,
+            client,
+            clusterService,
+            auditLog,
+            securityIndexHandler,
+            configurationLoaderSecurity7,
+            new StandbyModeSetting(settings)
+        );
+    }
+
+    // visible for testing
+    protected ConfigurationRepository(
+        final String securityIndex,
+        final Settings settings,
+        final Path configPath,
+        final ThreadPool threadPool,
+        final Client client,
+        final ClusterService clusterService,
+        final AuditLog auditLog,
+        final SecurityIndexHandler securityIndexHandler,
+        final ConfigurationLoaderSecurity7 configurationLoaderSecurity7,
+        final OpensearchDynamicSetting<Boolean> standbyModeSetting
+    ) {
         this.securityIndex = securityIndex;
         this.settings = settings;
         this.configPath = configPath;
@@ -155,6 +186,7 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
         configCache = CacheBuilder.newBuilder().build();
         this.securityIndexHandler = securityIndexHandler;
         this.reloadThread = new ReloadThread(settings, this::doReload);
+        this.standbyModeSetting = standbyModeSetting;
     }
 
     private Path resolveConfigDir() {
@@ -168,8 +200,7 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
         final SecurityMetadata securityMetadata = event.state().custom(SecurityMetadata.TYPE);
         // In standby mode, skip security index creation/initialization.
         // The security index will be replicated from the leader cluster via CCR.
-        final boolean standbyMode = settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false);
-        if (standbyMode) {
+        if (standbyModeEnabled()) {
             // Still load config from the replicated index if it exists
             if (securityMetadata != null) {
                 executeConfigurationInitialization(securityMetadata);
@@ -178,6 +209,7 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
             startConfigPollingIfNeeded();
             return;
         }
+        stopConfigPollingIfNeeded();
         // init and upload sec index on the manager node only as soon as
         // creation of index and upload config are done a new cluster state will be created.
         // in case of failures it repeats attempt after restart
@@ -205,6 +237,10 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
         LOGGER.info("Standby mode: starting config index polling for CCR-replicated changes");
         configPollingTask = threadPool.scheduleWithFixedDelay(() -> {
             try {
+                if (!standbyModeEnabled()) {
+                    stopConfigPollingIfNeeded();
+                    return;
+                }
                 if (!clusterService.state().metadata().hasConcreteIndex(securityIndex)) {
                     return; // index not yet replicated
                 }
@@ -234,6 +270,18 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
         }, TimeValue.timeValueSeconds(5), ThreadPool.Names.GENERIC);
     }
 
+    private void stopConfigPollingIfNeeded() {
+        if (configPollingTask != null) {
+            LOGGER.info("Standby mode disabled: stopping config index polling");
+            configPollingTask.cancel();
+            configPollingTask = null;
+        }
+    }
+
+    private boolean standbyModeEnabled() {
+        return standbyModeSetting.getDynamicSettingValue();
+    }
+
     private boolean nodeSelectedAsManager(final ClusterChangedEvent event) {
         boolean wasClusterManager = event.previousState().nodes().isLocalNodeElectedClusterManager();
         boolean isClusterManager = event.localNodeClusterManager();
@@ -253,7 +301,7 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
             LOGGER.info("Background init thread started. Install default config?: " + installDefaultConfig);
 
             // In standby mode, skip all initialization — config will come from CCR replication
-            if (settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false)) {
+            if (standbyModeEnabled()) {
                 LOGGER.info("Standby mode enabled — skipping security index initialization");
                 return;
             }
@@ -556,6 +604,18 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
         ClusterService clusterService,
         AuditLog auditLog
     ) {
+        return create(settings, configPath, threadPool, client, clusterService, auditLog, new StandbyModeSetting(settings));
+    }
+
+    public static ConfigurationRepository create(
+        Settings settings,
+        final Path configPath,
+        final ThreadPool threadPool,
+        Client client,
+        ClusterService clusterService,
+        AuditLog auditLog,
+        OpensearchDynamicSetting<Boolean> standbyModeSetting
+    ) {
         final var securityIndex = settings.get(
             ConfigConstants.SECURITY_CONFIG_INDEX_NAME,
             ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX
@@ -569,7 +629,8 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
             clusterService,
             auditLog,
             new SecurityIndexHandler(securityIndex, settings, client),
-            new ConfigurationLoaderSecurity7(client, threadPool, settings, clusterService)
+            new ConfigurationLoaderSecurity7(client, threadPool, settings, clusterService),
+            standbyModeSetting
         );
     }
 

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -68,6 +68,7 @@ import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.util.concurrent.ThreadContext.StoredContext;
@@ -93,6 +94,7 @@ import org.opensearch.security.state.SecurityMetadata;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.ConfigHelper;
 import org.opensearch.security.support.SecurityIndexHandler;
+import org.opensearch.threadpool.Scheduler.Cancellable;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -125,6 +127,8 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
     private final SecurityIndexHandler securityIndexHandler;
 
     private final ReloadThread reloadThread;
+
+    private volatile Cancellable configPollingTask;
 
     // visible for testing
     protected ConfigurationRepository(
@@ -162,6 +166,18 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
     @Override
     public void clusterChanged(final ClusterChangedEvent event) {
         final SecurityMetadata securityMetadata = event.state().custom(SecurityMetadata.TYPE);
+        // In standby mode, skip security index creation/initialization.
+        // The security index will be replicated from the leader cluster via CCR.
+        final boolean standbyMode = settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false);
+        if (standbyMode) {
+            // Still load config from the replicated index if it exists
+            if (securityMetadata != null) {
+                executeConfigurationInitialization(securityMetadata);
+            }
+            // Start polling for config index changes from CCR replication
+            startConfigPollingIfNeeded();
+            return;
+        }
         // init and upload sec index on the manager node only as soon as
         // creation of index and upload config are done a new cluster state will be created.
         // in case of failures it repeats attempt after restart
@@ -175,6 +191,47 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
         if (securityMetadata != null) {
             executeConfigurationInitialization(securityMetadata);
         }
+    }
+
+    /**
+     * In standby mode, CCR replicates the security index from the leader cluster but the normal
+     * config reload triggers (REST API writes, ConfigUpdateAction) don't fire. This method starts
+     * a periodic poll that detects changes in the replicated security index and reloads config.
+     */
+    private void startConfigPollingIfNeeded() {
+        if (configPollingTask != null) {
+            return; // already polling
+        }
+        LOGGER.info("Standby mode: starting config index polling for CCR-replicated changes");
+        configPollingTask = threadPool.scheduleWithFixedDelay(() -> {
+            try {
+                if (!clusterService.state().metadata().hasConcreteIndex(securityIndex)) {
+                    return; // index not yet replicated
+                }
+                final ThreadContext threadContext = threadPool.getThreadContext();
+                try (StoredContext ctx = threadContext.stashContext()) {
+                    threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true");
+                    if (!initalizeConfigTask.isDone()) {
+                        // First time seeing the index — do initial config load
+                        LOGGER.info("Standby mode: security index detected, loading initial configuration");
+                        ConfigurationMap loaded = getConfigurationsFromIndex(CType.values(), false, acceptInvalid);
+                        configCache.putAll(loaded.rawMap());
+                        notifyAboutChanges(loaded);
+                        final var auditConfigDocPresent = loaded.containsKey(CType.AUDIT) && loaded.get(CType.AUDIT).notEmpty();
+                        setupAuditConfigurationIfAny(auditConfigDocPresent);
+                        auditHotReloadingEnabled.getAndSet(auditConfigDocPresent);
+                        initalizeConfigTask.complete(null);
+                        this.reloadThread.start();
+                        LOGGER.info("Standby mode: security configuration initialized from replicated index");
+                    } else {
+                        // Subsequent polls — reload to pick up changes
+                        doReload(CType.values());
+                    }
+                }
+            } catch (Exception e) {
+                LOGGER.debug("Standby config poll failed, will retry", e);
+            }
+        }, TimeValue.timeValueSeconds(5), ThreadPool.Names.GENERIC);
     }
 
     private boolean nodeSelectedAsManager(final ClusterChangedEvent event) {
@@ -194,6 +251,13 @@ public class ConfigurationRepository implements ClusterStateListener, IndexEvent
     private void initalizeClusterConfiguration(final boolean installDefaultConfig) {
         try {
             LOGGER.info("Background init thread started. Install default config?: " + installDefaultConfig);
+
+            // In standby mode, skip all initialization — config will come from CCR replication
+            if (settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false)) {
+                LOGGER.info("Standby mode enabled — skipping security index initialization");
+                return;
+            }
+
             // wait for the cluster here until it will finish managed node election
             while (clusterService.state().blocks().hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE)) {
                 LOGGER.info("Wait for cluster to be available ...");

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
@@ -475,7 +475,7 @@ public abstract class AbstractApiAction extends BaseRestHandler implements RestR
     }
 
     protected boolean isStandbyMode() {
-        return securityApiDependencies.settings().getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false);
+        return securityApiDependencies.standbyModeEnabled();
     }
 
     abstract static class OnSucessActionListener<Response> implements ActionListener<Response> {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
@@ -474,6 +474,10 @@ public abstract class AbstractApiAction extends BaseRestHandler implements RestR
         return clusterService.state().metadata().hasConcreteIndex(securityApiDependencies.securityIndexName());
     }
 
+    protected boolean isStandbyMode() {
+        return securityApiDependencies.settings().getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false);
+    }
+
     abstract static class OnSucessActionListener<Response> implements ActionListener<Response> {
 
         private final RestChannel channel;
@@ -591,6 +595,15 @@ public abstract class AbstractApiAction extends BaseRestHandler implements RestR
         // check if .opendistro_security index has been initialized
         if (!ensureIndexExists()) {
             return channel -> internalServerError(channel, RequestContentValidator.ValidationError.SECURITY_NOT_INITIALIZED.message());
+        }
+
+        // check if cluster is in standby mode — reject config mutations (writes only)
+        if (isStandbyMode() && request.method() != Method.GET) {
+            return channel -> forbidden(
+                channel,
+                "Security configuration is read-only because this cluster is in standby mode. "
+                    + "Promote the cluster before updating security configuration."
+            );
         }
 
         // check if request is authorized

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityApiDependencies.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityApiDependencies.java
@@ -16,6 +16,8 @@ import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
 import org.opensearch.security.privileges.PrivilegesConfiguration;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
+import org.opensearch.security.setting.StandbyModeSetting;
 import org.opensearch.security.support.ConfigConstants;
 
 public class SecurityApiDependencies {
@@ -25,6 +27,7 @@ public class SecurityApiDependencies {
     private final RestApiAdminPrivilegesEvaluator restApiAdminPrivilegesEvaluator;
     private final AuditLog auditLog;
     private final Settings settings;
+    private final OpensearchDynamicSetting<Boolean> standbyModeSetting;
 
     private final PrivilegesConfiguration privilegesConfiguration;
 
@@ -35,7 +38,8 @@ public class SecurityApiDependencies {
         final RestApiPrivilegesEvaluator restApiPrivilegesEvaluator,
         final RestApiAdminPrivilegesEvaluator restApiAdminPrivilegesEvaluator,
         final AuditLog auditLog,
-        final Settings settings
+        final Settings settings,
+        final OpensearchDynamicSetting<Boolean> standbyModeSetting
     ) {
         this.adminDNs = adminDNs;
         this.configurationRepository = configurationRepository;
@@ -44,6 +48,28 @@ public class SecurityApiDependencies {
         this.restApiAdminPrivilegesEvaluator = restApiAdminPrivilegesEvaluator;
         this.auditLog = auditLog;
         this.settings = settings;
+        this.standbyModeSetting = standbyModeSetting;
+    }
+
+    public SecurityApiDependencies(
+        final AdminDNs adminDNs,
+        final ConfigurationRepository configurationRepository,
+        final PrivilegesConfiguration privilegesConfiguration,
+        final RestApiPrivilegesEvaluator restApiPrivilegesEvaluator,
+        final RestApiAdminPrivilegesEvaluator restApiAdminPrivilegesEvaluator,
+        final AuditLog auditLog,
+        final Settings settings
+    ) {
+        this(
+            adminDNs,
+            configurationRepository,
+            privilegesConfiguration,
+            restApiPrivilegesEvaluator,
+            restApiAdminPrivilegesEvaluator,
+            auditLog,
+            settings,
+            new StandbyModeSetting(settings)
+        );
     }
 
     public AdminDNs adminDNs() {
@@ -72,6 +98,10 @@ public class SecurityApiDependencies {
 
     public Settings settings() {
         return settings;
+    }
+
+    public boolean standbyModeEnabled() {
+        return standbyModeSetting.getDynamicSettingValue();
     }
 
     public String securityIndexName() {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
@@ -31,6 +31,7 @@ import org.opensearch.security.privileges.RoleMapper;
 import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.resources.ResourceSharingIndexHandler;
 import org.opensearch.security.resources.api.migrate.MigrateResourceSharingInfoApiAction;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
 import org.opensearch.security.ssl.SslSettingsManager;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.security.user.UserService;
@@ -59,7 +60,8 @@ public class SecurityRestApiActions {
         final boolean certificatesReloadEnabled,
         final PasswordHasher passwordHasher,
         final ResourceSharingIndexHandler resourceSharingIndexHandler,
-        final ResourcePluginInfo resourcePluginInfo
+        final ResourcePluginInfo resourcePluginInfo,
+        final OpensearchDynamicSetting<Boolean> standbyModeSetting
     ) {
         final var securityApiDependencies = new SecurityApiDependencies(
             adminDns,
@@ -73,7 +75,8 @@ public class SecurityRestApiActions {
                 settings.getAsBoolean(SECURITY_RESTAPI_ADMIN_ENABLED, false)
             ),
             auditLog,
-            settings
+            settings,
+            standbyModeSetting
         );
         List<RestHandler> handler = new ArrayList<>(
             List.of(

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -97,6 +97,8 @@ import org.opensearch.security.privileges.PrivilegesEvaluationContext;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.privileges.PrivilegesEvaluatorResponse;
 import org.opensearch.security.privileges.ResourceAccessEvaluator;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
+import org.opensearch.security.setting.StandbyModeSetting;
 import org.opensearch.security.support.Base64Helper;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.HeaderHelper;
@@ -129,7 +131,7 @@ public class SecurityFilter implements ActionFilter {
     private final ResourceAccessEvaluator resourceAccessEvaluator;
     private final ThreadContextUserInfo threadContextUserInfo;
     private final Set<String> restApiAllowedRoles;
-    private final boolean standbyMode;
+    private final OpensearchDynamicSetting<Boolean> standbyModeSetting;
 
     public SecurityFilter(
         final Settings settings,
@@ -142,6 +144,34 @@ public class SecurityFilter implements ActionFilter {
         final CompatConfig compatConfig,
         final XFFResolver xffResolver,
         ResourceAccessEvaluator resourceAccessEvaluator
+    ) {
+        this(
+            settings,
+            privilegesConfiguration,
+            adminDns,
+            dlsFlsValve,
+            auditLog,
+            threadPool,
+            cs,
+            compatConfig,
+            xffResolver,
+            resourceAccessEvaluator,
+            new StandbyModeSetting(settings)
+        );
+    }
+
+    public SecurityFilter(
+        final Settings settings,
+        PrivilegesConfiguration privilegesConfiguration,
+        final AdminDNs adminDns,
+        DlsFlsRequestValve dlsFlsValve,
+        AuditLog auditLog,
+        ThreadPool threadPool,
+        ClusterService cs,
+        final CompatConfig compatConfig,
+        final XFFResolver xffResolver,
+        ResourceAccessEvaluator resourceAccessEvaluator,
+        OpensearchDynamicSetting<Boolean> standbyModeSetting
     ) {
         this.privilegesConfiguration = privilegesConfiguration;
         this.adminDns = adminDns;
@@ -157,7 +187,7 @@ public class SecurityFilter implements ActionFilter {
         this.userInjector = new UserInjector(settings, threadPool, auditLog, xffResolver);
         this.resourceAccessEvaluator = resourceAccessEvaluator;
         this.restApiAllowedRoles = Set.copyOf(settings.getAsList(ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED));
-        this.standbyMode = settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false);
+        this.standbyModeSetting = standbyModeSetting;
         this.threadContextUserInfo = new ThreadContextUserInfo(
             threadPool.getThreadContext(),
             privilegesConfiguration,
@@ -576,7 +606,7 @@ public class SecurityFilter implements ActionFilter {
     }
 
     private boolean isAllowedStandbyCcrSystemIndexReplication(String action, ActionRequest request) {
-        if (standbyMode == false) {
+        if (standbyModeSetting.getDynamicSettingValue() == false) {
             return false;
         }
         final String replicatedSystemIndex = threadPool.getThreadContext()

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -44,6 +44,7 @@ import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocWriteRequest.OpType;
+import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
@@ -78,6 +79,7 @@ import org.opensearch.core.common.logging.LoggerMessageFormat;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.index.reindex.UpdateByQueryRequest;
+import org.opensearch.indices.SystemIndexRegistry;
 import org.opensearch.security.action.simulate.PermissionCheckResponse;
 import org.opensearch.security.action.whoami.WhoAmIAction;
 import org.opensearch.security.auditlog.AuditLog;
@@ -111,6 +113,8 @@ import static org.opensearch.security.support.ConfigConstants.SECURITY_PERFORM_P
 
 public class SecurityFilter implements ActionFilter {
 
+    private static final String CCR_REPLAY_CHANGES_ACTION = "indices:data/write/plugins/replication/changes";
+
     protected final Logger log = LogManager.getLogger(this.getClass());
     private final PrivilegesConfiguration privilegesConfiguration;
     private final AdminDNs adminDns;
@@ -125,6 +129,7 @@ public class SecurityFilter implements ActionFilter {
     private final ResourceAccessEvaluator resourceAccessEvaluator;
     private final ThreadContextUserInfo threadContextUserInfo;
     private final Set<String> restApiAllowedRoles;
+    private final boolean standbyMode;
 
     public SecurityFilter(
         final Settings settings,
@@ -152,6 +157,7 @@ public class SecurityFilter implements ActionFilter {
         this.userInjector = new UserInjector(settings, threadPool, auditLog, xffResolver);
         this.resourceAccessEvaluator = resourceAccessEvaluator;
         this.restApiAllowedRoles = Set.copyOf(settings.getAsList(ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED));
+        this.standbyMode = settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false);
         this.threadContextUserInfo = new ThreadContextUserInfo(
             threadPool.getThreadContext(),
             privilegesConfiguration,
@@ -389,6 +395,16 @@ public class SecurityFilter implements ActionFilter {
                     }
             }
 
+            if (isAllowedStandbyCcrSystemIndexReplication(action, request)) {
+                log.debug(
+                    "Allowing standby CCR replicated system index operation before Security configuration is initialized: action=[{}], index=[{}]",
+                    action,
+                    threadContext.getTransient(ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_THREAD_CONTEXT)
+                );
+                chain.proceed(task, action, request, listener);
+                return;
+            }
+
             final PrivilegesEvaluator eval = this.privilegesConfiguration.privilegesEvaluator();
 
             if (log.isTraceEnabled()) {
@@ -557,6 +573,31 @@ public class SecurityFilter implements ActionFilter {
 
     private static boolean isUserAdmin(User user, final AdminDNs adminDns) {
         return user != null && adminDns.isAdmin(user);
+    }
+
+    private boolean isAllowedStandbyCcrSystemIndexReplication(String action, ActionRequest request) {
+        if (standbyMode == false) {
+            return false;
+        }
+        final String replicatedSystemIndex = threadPool.getThreadContext()
+            .getTransient(ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_THREAD_CONTEXT);
+        if (replicatedSystemIndex == null || SystemIndexRegistry.matchesSystemIndexPattern(replicatedSystemIndex) == false) {
+            return false;
+        }
+        if (request instanceof RestoreSnapshotRequest) {
+            return isSingleIndexRequest(((RestoreSnapshotRequest) request).indices(), replicatedSystemIndex);
+        }
+        return CCR_REPLAY_CHANGES_ACTION.equals(action)
+            && request instanceof IndicesRequest
+            && isSingleIndexRequest((IndicesRequest) request, replicatedSystemIndex);
+    }
+
+    private boolean isSingleIndexRequest(IndicesRequest request, String expectedIndex) {
+        return isSingleIndexRequest(request.indices(), expectedIndex);
+    }
+
+    private boolean isSingleIndexRequest(String[] indices, String expectedIndex) {
+        return indices != null && indices.length == 1 && expectedIndex.equals(indices[0]);
     }
 
     private void attachSourceFieldContext(ActionRequest request) {

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -47,6 +47,7 @@ import org.opensearch.security.securityconf.FlattenedActionGroups;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.ConfigV7;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
 import org.opensearch.security.user.User;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
@@ -304,7 +305,7 @@ public interface PrivilegesEvaluator {
     record CoreDependencies(ClusterService clusterService, Supplier<ClusterState> clusterStateSupplier, Client client,
         RoleMapper roleMapper, ThreadPool threadPool, ThreadContext threadContext, AuditLog auditLog, Settings settings,
         IndexNameExpressionResolver indexNameExpressionResolver, Supplier<String> unavailablityReasonSupplier,
-        NamedXContentRegistry namedXContentRegistry) {
+        NamedXContentRegistry namedXContentRegistry, OpensearchDynamicSetting<Boolean> standbyModeSetting) {
     }
 
     /**

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
@@ -187,7 +187,7 @@ public class PrivilegesEvaluatorImpl implements PrivilegesEvaluator {
             isLocalNodeElectedClusterManager
         );
         snapshotRestoreEvaluator = new SnapshotRestoreEvaluator(settings, auditLog, isLocalNodeElectedClusterManager);
-        systemIndexAccessEvaluator = new SystemIndexAccessEvaluator(settings, auditLog, irr);
+        systemIndexAccessEvaluator = new SystemIndexAccessEvaluator(settings, auditLog, irr, threadContext);
         protectedIndexAccessEvaluator = new ProtectedIndexAccessEvaluator(settings, auditLog);
         termsAggregationEvaluator = new TermsAggregationEvaluator();
         pitPrivilegesEvaluator = new PitPrivilegesEvaluator();

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
@@ -187,7 +187,13 @@ public class PrivilegesEvaluatorImpl implements PrivilegesEvaluator {
             isLocalNodeElectedClusterManager
         );
         snapshotRestoreEvaluator = new SnapshotRestoreEvaluator(settings, auditLog, isLocalNodeElectedClusterManager);
-        systemIndexAccessEvaluator = new SystemIndexAccessEvaluator(settings, auditLog, irr, threadContext);
+        systemIndexAccessEvaluator = new SystemIndexAccessEvaluator(
+            settings,
+            auditLog,
+            irr,
+            threadContext,
+            coreDependencies.standbyModeSetting()
+        );
         protectedIndexAccessEvaluator = new ProtectedIndexAccessEvaluator(settings, auditLog);
         termsAggregationEvaluator = new TermsAggregationEvaluator();
         pitPrivilegesEvaluator = new PitPrivilegesEvaluator();

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluator.java
@@ -47,6 +47,8 @@ import org.opensearch.security.privileges.ActionPrivileges;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
 import org.opensearch.security.privileges.PrivilegesEvaluatorResponse;
 import org.opensearch.security.privileges.actionlevel.legacy.IndexResolverReplacer.Resolved;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
+import org.opensearch.security.setting.StandbyModeSetting;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.security.user.User;
@@ -73,13 +75,19 @@ public class SystemIndexAccessEvaluator {
     private final WildcardMatcher superAdminAccessOnlyIndexMatcher;
     private final WildcardMatcher deniedActionsMatcher;
     private final ThreadContext threadContext;
-    private final boolean standbyMode;
+    private final OpensearchDynamicSetting<Boolean> standbyModeSetting;
 
     private final boolean isSystemIndexEnabled;
     private final boolean isSystemIndexPermissionEnabled;
     private final static ImmutableSet<String> SYSTEM_INDEX_PERMISSION_SET = ImmutableSet.of(ConfigConstants.SYSTEM_INDEX_PERMISSION);
 
-    public SystemIndexAccessEvaluator(final Settings settings, AuditLog auditLog, IndexResolverReplacer irr, ThreadContext threadContext) {
+    public SystemIndexAccessEvaluator(
+        final Settings settings,
+        AuditLog auditLog,
+        IndexResolverReplacer irr,
+        ThreadContext threadContext,
+        OpensearchDynamicSetting<Boolean> standbyModeSetting
+    ) {
         this.securityIndex = settings.get(
             ConfigConstants.SECURITY_CONFIG_INDEX_NAME,
             ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX
@@ -87,7 +95,7 @@ public class SystemIndexAccessEvaluator {
         this.auditLog = auditLog;
         this.irr = irr;
         this.threadContext = threadContext;
-        this.standbyMode = settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false);
+        this.standbyModeSetting = standbyModeSetting;
         this.filterSecurityIndex = settings.getAsBoolean(ConfigConstants.SECURITY_FILTER_SECURITYINDEX_FROM_ALL_REQUESTS, false);
         this.systemIndexMatcher = WildcardMatcher.from(
             settings.getAsList(ConfigConstants.SECURITY_SYSTEM_INDICES_KEY, ConfigConstants.SECURITY_SYSTEM_INDICES_DEFAULT)
@@ -119,7 +127,7 @@ public class SystemIndexAccessEvaluator {
     }
 
     public SystemIndexAccessEvaluator(final Settings settings, AuditLog auditLog, IndexResolverReplacer irr) {
-        this(settings, auditLog, irr, new ThreadContext(Settings.EMPTY));
+        this(settings, auditLog, irr, new ThreadContext(Settings.EMPTY), new StandbyModeSetting(settings));
     }
 
     private static List<String> deniedActionPatterns() {
@@ -249,7 +257,7 @@ public class SystemIndexAccessEvaluator {
     }
 
     private boolean isAllowedStandbyReplicatedSystemIndex(final String index) {
-        if (standbyMode == false) {
+        if (standbyModeSetting.getDynamicSettingValue() == false) {
             log.debug("Standby CCR replicated system index [{}] denied because standby mode is disabled", index);
             return false;
         }

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluator.java
@@ -40,6 +40,7 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.RealtimeRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.indices.SystemIndexRegistry;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.privileges.ActionPrivileges;
@@ -71,18 +72,22 @@ public class SystemIndexAccessEvaluator {
     private final WildcardMatcher systemIndexMatcher;
     private final WildcardMatcher superAdminAccessOnlyIndexMatcher;
     private final WildcardMatcher deniedActionsMatcher;
+    private final ThreadContext threadContext;
+    private final boolean standbyMode;
 
     private final boolean isSystemIndexEnabled;
     private final boolean isSystemIndexPermissionEnabled;
     private final static ImmutableSet<String> SYSTEM_INDEX_PERMISSION_SET = ImmutableSet.of(ConfigConstants.SYSTEM_INDEX_PERMISSION);
 
-    public SystemIndexAccessEvaluator(final Settings settings, AuditLog auditLog, IndexResolverReplacer irr) {
+    public SystemIndexAccessEvaluator(final Settings settings, AuditLog auditLog, IndexResolverReplacer irr, ThreadContext threadContext) {
         this.securityIndex = settings.get(
             ConfigConstants.SECURITY_CONFIG_INDEX_NAME,
             ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX
         );
         this.auditLog = auditLog;
         this.irr = irr;
+        this.threadContext = threadContext;
+        this.standbyMode = settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false);
         this.filterSecurityIndex = settings.getAsBoolean(ConfigConstants.SECURITY_FILTER_SECURITYINDEX_FROM_ALL_REQUESTS, false);
         this.systemIndexMatcher = WildcardMatcher.from(
             settings.getAsList(ConfigConstants.SECURITY_SYSTEM_INDICES_KEY, ConfigConstants.SECURITY_SYSTEM_INDICES_DEFAULT)
@@ -111,6 +116,10 @@ public class SystemIndexAccessEvaluator {
             ConfigConstants.SECURITY_SYSTEM_INDICES_PERMISSIONS_ENABLED_KEY,
             ConfigConstants.SECURITY_SYSTEM_INDICES_PERMISSIONS_DEFAULT
         );
+    }
+
+    public SystemIndexAccessEvaluator(final Settings settings, AuditLog auditLog, IndexResolverReplacer irr) {
+        this(settings, auditLog, irr, new ThreadContext(Settings.EMPTY));
     }
 
     private static List<String> deniedActionPatterns() {
@@ -234,6 +243,33 @@ public class SystemIndexAccessEvaluator {
         return allIndices.stream().anyMatch(index -> !allSystemIndices.contains(index) && !allProtectedSystemIndices.contains(index));
     }
 
+    private boolean requestContainsOnlyAllowedStandbyReplicatedSystemIndices(final Resolved requestedResolved) {
+        return requestedResolved.getAllIndices().isEmpty() == false
+            && requestedResolved.getAllIndices().stream().allMatch(this::isAllowedStandbyReplicatedSystemIndex);
+    }
+
+    private boolean isAllowedStandbyReplicatedSystemIndex(final String index) {
+        if (standbyMode == false) {
+            log.debug("Standby CCR replicated system index [{}] denied because standby mode is disabled", index);
+            return false;
+        }
+        final String replicatedSystemIndex = threadContext.getTransient(ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_THREAD_CONTEXT);
+        final boolean registeredSystemIndex = isRegisteredSystemIndex(index);
+        final boolean allowed = index.equals(replicatedSystemIndex) && registeredSystemIndex;
+        log.info(
+            "Evaluated standby CCR replicated system index [{}]: marker=[{}], registered=[{}], allowed=[{}]",
+            index,
+            replicatedSystemIndex,
+            registeredSystemIndex,
+            allowed
+        );
+        return allowed;
+    }
+
+    private boolean isRegisteredSystemIndex(final String index) {
+        return securityIndex.equals(index) || SystemIndexRegistry.matchesSystemIndexPattern(index);
+    }
+
     /**
      * Is the current action allowed to be performed on security index
      * @param action request action on security index
@@ -282,6 +318,11 @@ public class SystemIndexAccessEvaluator {
         boolean containsSystemIndex = requestContainsAnySystemIndices(requestedResolved);
         boolean containsRegularIndex = requestContainsAnyRegularIndices(requestedResolved);
         boolean serviceAccountUser = user.isServiceAccount();
+
+        if (containsSystemIndex && requestContainsOnlyAllowedStandbyReplicatedSystemIndices(requestedResolved)) {
+            log.debug("Allowing standby CCR replicated system index request for {}", requestedResolved.getAllIndices());
+            return PrivilegesEvaluatorResponse.ok();
+        }
 
         // Calculate plugin-related information once for reuse
         final Set<String> matchingPluginIndices = getMatchingPluginIndices(user, requestedResolved);

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImpl.java
@@ -53,6 +53,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.indices.SystemIndexRegistry;
 import org.opensearch.security.privileges.ActionPrivileges;
 import org.opensearch.security.privileges.CompiledRoles;
 import org.opensearch.security.privileges.DocumentAllowList;
@@ -144,8 +145,9 @@ public class PrivilegesEvaluatorImpl implements org.opensearch.security.privileg
         this.clusterStateSupplier = coreDependencies.clusterStateSupplier();
         this.settings = coreDependencies.settings();
         this.specialIndexProtection = new RuntimeOptimizedActionPrivileges.SpecialIndexProtection(
-            dynamicDependencies.specialIndices()::isUniversallyDeniedIndex,
-            dynamicDependencies.specialIndices()::isSystemIndex,
+            index -> dynamicDependencies.specialIndices().isUniversallyDeniedIndex(index)
+                && isAllowedStandbyReplicatedSystemIndex(index) == false,
+            index -> dynamicDependencies.specialIndices().isSystemIndex(index) && isAllowedStandbyReplicatedSystemIndex(index) == false,
             indicesNeedingSpecialRoles(settings)
         );
 
@@ -197,6 +199,28 @@ public class PrivilegesEvaluatorImpl implements org.opensearch.security.privileg
         }
 
         this.indexReductionEnabled = globalDynamicSettings.ignoreUnauthorizedIndices;
+    }
+
+    private boolean isAllowedStandbyReplicatedSystemIndex(String index) {
+        if (settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false) == false) {
+            log.debug("Standby CCR replicated system index [{}] denied because standby mode is disabled", index);
+            return false;
+        }
+        final String replicatedSystemIndex = threadContext.getTransient(ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_THREAD_CONTEXT);
+        final boolean registeredSystemIndex = isRegisteredSystemIndex(index);
+        final boolean allowed = index.equals(replicatedSystemIndex) && registeredSystemIndex;
+        log.info(
+            "Evaluated standby CCR replicated system index [{}]: marker=[{}], registered=[{}], allowed=[{}]",
+            index,
+            replicatedSystemIndex,
+            registeredSystemIndex,
+            allowed
+        );
+        return allowed;
+    }
+
+    private boolean isRegisteredSystemIndex(String index) {
+        return SystemIndexRegistry.matchesSystemIndexPattern(index);
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImpl.java
@@ -67,6 +67,7 @@ import org.opensearch.security.privileges.actionlevel.RuntimeOptimizedActionPriv
 import org.opensearch.security.privileges.actionlevel.SubjectBasedActionPrivileges;
 import org.opensearch.security.securityconf.FlattenedActionGroups;
 import org.opensearch.security.securityconf.impl.v7.ConfigV7;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.SnapshotRestoreHelper;
 import org.opensearch.security.support.WildcardMatcher;
@@ -135,6 +136,7 @@ public class PrivilegesEvaluatorImpl implements org.opensearch.security.privileg
     private final ThreadPool threadPool;
     private final RuntimeOptimizedActionPrivileges.SpecialIndexProtection specialIndexProtection;
     private final ActionConfiguration actionConfiguration;
+    private final OpensearchDynamicSetting<Boolean> standbyModeSetting;
     private volatile boolean indexReductionEnabled = true;
 
     public PrivilegesEvaluatorImpl(CoreDependencies coreDependencies, DynamicDependencies dynamicDependencies) {
@@ -144,6 +146,7 @@ public class PrivilegesEvaluatorImpl implements org.opensearch.security.privileg
         this.threadPool = coreDependencies.threadPool();
         this.clusterStateSupplier = coreDependencies.clusterStateSupplier();
         this.settings = coreDependencies.settings();
+        this.standbyModeSetting = coreDependencies.standbyModeSetting();
         this.specialIndexProtection = new RuntimeOptimizedActionPrivileges.SpecialIndexProtection(
             index -> dynamicDependencies.specialIndices().isUniversallyDeniedIndex(index)
                 && isAllowedStandbyReplicatedSystemIndex(index) == false,
@@ -202,7 +205,7 @@ public class PrivilegesEvaluatorImpl implements org.opensearch.security.privileg
     }
 
     private boolean isAllowedStandbyReplicatedSystemIndex(String index) {
-        if (settings.getAsBoolean(ConfigConstants.SECURITY_STANDBY_MODE, false) == false) {
+        if (standbyModeSetting.getDynamicSettingValue() == false) {
             log.debug("Standby CCR replicated system index [{}] denied because standby mode is disabled", index);
             return false;
         }

--- a/src/main/java/org/opensearch/security/setting/StandbyModeSetting.java
+++ b/src/main/java/org/opensearch/security/setting/StandbyModeSetting.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.setting;
+
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Setting.Property;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.support.ConfigConstants;
+
+public class StandbyModeSetting extends OpensearchDynamicSetting<Boolean> {
+
+    public static final Setting<Boolean> STANDBY_MODE = Setting.boolSetting(
+        ConfigConstants.SECURITY_STANDBY_MODE,
+        false,
+        Property.NodeScope,
+        Property.Dynamic,
+        Property.Sensitive
+    );
+
+    public StandbyModeSetting(final Settings settings) {
+        super(STANDBY_MODE, STANDBY_MODE.get(settings));
+    }
+
+    @Override
+    protected String getClusterChangeMessage(final Boolean standbyMode) {
+        return String.format("Detected change in settings, security standby mode is %s", standbyMode ? "enabled" : "disabled");
+    }
+}

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -287,6 +287,8 @@ public class ConfigConstants {
     public static final String SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED = SECURITY_SETTINGS_PREFIX + "nodes_dn_dynamic_config_enabled";
     public static final String SECURITY_DISABLED = SECURITY_SETTINGS_PREFIX + "disabled";
 
+    public static final String SECURITY_STANDBY_MODE = SECURITY_SETTINGS_PREFIX + "standby_mode";
+
     public static final String SECURITY_CACHE_TTL_MINUTES = SECURITY_SETTINGS_PREFIX + "cache.ttl_minutes";
     public static final String SECURITY_ALLOW_UNSAFE_DEMOCERTIFICATES = SECURITY_SETTINGS_PREFIX + "allow_unsafe_democertificates";
     public static final String SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX = SECURITY_SETTINGS_PREFIX + "allow_default_init_securityindex";

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -288,6 +288,8 @@ public class ConfigConstants {
     public static final String SECURITY_DISABLED = SECURITY_SETTINGS_PREFIX + "disabled";
 
     public static final String SECURITY_STANDBY_MODE = SECURITY_SETTINGS_PREFIX + "standby_mode";
+    public static final String CCR_REPLICATED_SYSTEM_INDEX_THREAD_CONTEXT = "opensearch.ccr.replicated_system_index";
+    public static final String CCR_REPLICATED_SYSTEM_INDEX_HEADER = "opensearch_ccr_replicated_system_index";
 
     public static final String SECURITY_CACHE_TTL_MINUTES = SECURITY_SETTINGS_PREFIX + "cache.ttl_minutes";
     public static final String SECURITY_ALLOW_UNSAFE_DEMOCERTIFICATES = SECURITY_SETTINGS_PREFIX + "allow_unsafe_democertificates";

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -154,6 +154,7 @@ public class SecurityInterceptor {
         final String injectedRolesValidationString = getThreadContext().getTransient(
             ConfigConstants.OPENDISTRO_SECURITY_INJECTED_ROLES_VALIDATION
         );
+        final String ccrReplicatedSystemIndex = getThreadContext().getTransient(ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_THREAD_CONTEXT);
         final String origin0 = getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN);
         final Object remoteAddress0 = getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
         final String origCCSTransientDls = getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_CCS);
@@ -263,7 +264,16 @@ public class SecurityInterceptor {
 
             getThreadContext().putHeader(headerMap);
 
-            ensureCorrectHeaders(remoteAddress0, user0, authUserSubj, origin0, injectedUserString, injectedRolesString, isSameNodeRequest);
+            ensureCorrectHeaders(
+                remoteAddress0,
+                user0,
+                authUserSubj,
+                origin0,
+                injectedUserString,
+                injectedRolesString,
+                ccrReplicatedSystemIndex,
+                isSameNodeRequest
+            );
 
             if (actionTraceEnabled.get()) {
                 getThreadContext().putHeader(
@@ -291,6 +301,7 @@ public class SecurityInterceptor {
         final String origin,
         final String injectedUserString,
         final String injectedRolesString,
+        final String ccrReplicatedSystemIndex,
         final boolean isSameNodeRequest
     ) {
         // keep original address
@@ -328,6 +339,10 @@ public class SecurityInterceptor {
             } else if (StringUtils.isNotEmpty(injectedUserString)) {
                 getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, injectedUserString);
             }
+            if (StringUtils.isNotEmpty(ccrReplicatedSystemIndex)) {
+                log.debug("Preserving CCR replicated system index [{}] as same-node transport transient", ccrReplicatedSystemIndex);
+                getThreadContext().putTransient(ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_THREAD_CONTEXT, ccrReplicatedSystemIndex);
+            }
         } else {
             if (transportAddress != null) {
                 getThreadContext().putHeader(
@@ -364,6 +379,11 @@ public class SecurityInterceptor {
                 } else if (StringUtils.isNotEmpty(injectedUserString)) {
                     getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER_HEADER, injectedUserString);
                 }
+            }
+            if (StringUtils.isNotEmpty(ccrReplicatedSystemIndex)
+                && getThreadContext().getHeader(ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_HEADER) == null) {
+                log.debug("Preserving CCR replicated system index [{}] as transport header", ccrReplicatedSystemIndex);
+                getThreadContext().putHeader(ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_HEADER, ccrReplicatedSystemIndex);
             }
         }
     }

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -196,6 +196,9 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
 
                 final String injectedRolesHeader = getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_ROLES_HEADER);
                 final String injectedUserHeader = getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER_HEADER);
+                final String ccrReplicatedSystemIndexHeader = getThreadContext().getHeader(
+                    ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_HEADER
+                );
 
                 if (Strings.isNullOrEmpty(userHeader)) {
                     // Keeping role injection with higher priority as plugins under OpenSearch will be using this
@@ -208,6 +211,13 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
                 } else {
                     user = user != null ? user : this.userFactory.fromSerializedBase64(userHeader);
                     getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, user);
+                }
+                if (!Strings.isNullOrEmpty(ccrReplicatedSystemIndexHeader)) {
+                    log.debug("Restoring CCR replicated system index [{}] from transport header", ccrReplicatedSystemIndexHeader);
+                    getThreadContext().putTransient(
+                        ConfigConstants.CCR_REPLICATED_SYSTEM_INDEX_THREAD_CONTEXT,
+                        ccrReplicatedSystemIndexHeader
+                    );
                 }
 
                 String originalRemoteAddress = getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS_HEADER);

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -61,6 +61,7 @@ import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
 import org.opensearch.security.state.SecurityConfig;
 import org.opensearch.security.state.SecurityMetadata;
 import org.opensearch.security.support.ConfigConstants;
@@ -210,6 +211,21 @@ public class ConfigurationRepositoryTest {
             auditLog,
             securityIndexHandler,
             configurationLoaderSecurity7
+        );
+    }
+
+    private ConfigurationRepository createConfigurationRepository(Settings settings, OpensearchDynamicSetting<Boolean> standbyModeSetting) {
+        return new ConfigurationRepository(
+            settings.get(ConfigConstants.SECURITY_CONFIG_INDEX_NAME, ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX),
+            settings,
+            path,
+            threadPool,
+            localClient,
+            clusterService,
+            auditLog,
+            securityIndexHandler,
+            configurationLoaderSecurity7,
+            standbyModeSetting
         );
     }
 
@@ -376,6 +392,34 @@ public class ConfigurationRepositoryTest {
         configurationRepository.clusterChanged(event);
 
         verify(configurationRepository, never()).executeConfigurationInitialization(any());
+    }
+
+    @Test
+    public void testClusterChanged_whenStandbyModeDynamicallyEnabledShouldSkipSecurityIndexInitialization() {
+        @SuppressWarnings("unchecked")
+        final var standbyModeSetting = (OpensearchDynamicSetting<Boolean>) mock(OpensearchDynamicSetting.class);
+        when(standbyModeSetting.getDynamicSettingValue()).thenReturn(true);
+
+        final var configurationRepository = spy(createConfigurationRepository(Settings.EMPTY, standbyModeSetting));
+        configurationRepository.clusterChanged(event);
+
+        verify(configurationRepository, never()).initSecurityIndex(any());
+    }
+
+    @Test
+    public void testClusterChanged_whenStandbyModeDynamicallyDisabledShouldInitializeSecurityIndex() {
+        when(event.previousState().nodes().isLocalNodeElectedClusterManager()).thenReturn(false);
+        when(event.localNodeClusterManager()).thenReturn(true);
+
+        @SuppressWarnings("unchecked")
+        final var standbyModeSetting = (OpensearchDynamicSetting<Boolean>) mock(OpensearchDynamicSetting.class);
+        when(standbyModeSetting.getDynamicSettingValue()).thenReturn(false);
+
+        final var configurationRepository = spy(createConfigurationRepository(Settings.EMPTY, standbyModeSetting));
+        doNothing().when(configurationRepository).initSecurityIndex(any());
+        configurationRepository.clusterChanged(event);
+
+        verify(configurationRepository).initSecurityIndex(any());
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 
@@ -94,10 +95,12 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -349,8 +352,8 @@ public class ConfigurationRepositoryTest {
         when(event.previousState().nodes().isLocalNodeElectedClusterManager()).thenReturn(false);
         when(event.localNodeClusterManager()).thenReturn(true);
 
-        final var configurationRepository = mock(ConfigurationRepository.class);
-        doCallRealMethod().when(configurationRepository).clusterChanged(any());
+        final var configurationRepository = spy(createConfigurationRepository(Settings.EMPTY));
+        doNothing().when(configurationRepository).initSecurityIndex(any());
         configurationRepository.clusterChanged(event);
 
         verify(configurationRepository).initSecurityIndex(any());
@@ -360,8 +363,8 @@ public class ConfigurationRepositoryTest {
     public void testClusterChanged_shouldExecuteInitialization() {
         when(event.state().custom(SecurityMetadata.TYPE)).thenReturn(new SecurityMetadata(Instant.now(), Set.of()));
 
-        final var configurationRepository = mock(ConfigurationRepository.class);
-        doCallRealMethod().when(configurationRepository).clusterChanged(any());
+        final var configurationRepository = spy(createConfigurationRepository(Settings.EMPTY));
+        doReturn(CompletableFuture.completedFuture(null)).when(configurationRepository).executeConfigurationInitialization(any());
         configurationRepository.clusterChanged(event);
 
         verify(configurationRepository).executeConfigurationInitialization(any());
@@ -369,8 +372,7 @@ public class ConfigurationRepositoryTest {
 
     @Test
     public void testClusterChanged_shouldNotExecuteInitialization() {
-        final var configurationRepository = mock(ConfigurationRepository.class);
-        doCallRealMethod().when(configurationRepository).clusterChanged(any());
+        final var configurationRepository = spy(createConfigurationRepository(Settings.EMPTY));
         configurationRepository.clusterChanged(event);
 
         verify(configurationRepository, never()).executeConfigurationInitialization(any());

--- a/src/test/java/org/opensearch/security/setting/StandbyModeSettingTest.java
+++ b/src/test/java/org/opensearch/security/setting/StandbyModeSettingTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.setting;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.support.ConfigConstants;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StandbyModeSettingTest {
+
+    @Test
+    public void testStandbyModeTracksClusterSettingsUpdates() {
+        final Settings initialSettings = Settings.builder().put(ConfigConstants.SECURITY_STANDBY_MODE, true).build();
+        final StandbyModeSetting standbyModeSetting = new StandbyModeSetting(initialSettings);
+        final ClusterSettings clusterSettings = new ClusterSettings(initialSettings, Set.of(StandbyModeSetting.STANDBY_MODE));
+        standbyModeSetting.registerClusterSettingsChangeListener(clusterSettings);
+
+        assertTrue(standbyModeSetting.getDynamicSettingValue());
+
+        clusterSettings.applySettings(Settings.builder().put(ConfigConstants.SECURITY_STANDBY_MODE, false).build());
+        assertFalse(standbyModeSetting.getDynamicSettingValue());
+
+        clusterSettings.applySettings(Settings.builder().put(ConfigConstants.SECURITY_STANDBY_MODE, true).build());
+        assertTrue(standbyModeSetting.getDynamicSettingValue());
+    }
+}


### PR DESCRIPTION
### Description

This PR introduces a `plugins.security.standby_mode` setting that enables the security plugin to operate in a read-only standby mode, designed for disaster recovery (DR) architectures where a follower cluster receives replicated security configuration via Cross-Cluster Replication (CCR).

**Background:** Current CCR [does not support system indices](https://github.com/opensearch-project/cross-cluster-replication/blob/main/src/main/kotlin/org/opensearch/replication/util/ValidationUtil.kt#L106-L108) (indices starting with `.`). A companion [change to the CCR plugin](https://github.com/cwperks/cross-cluster-replication/pull/1) removes this restriction for the Security index path. However, even with that restriction lifted, the security plugin needs to be aware that it is operating as a follower: it should not bootstrap its own security index, should not accept config mutations, and should refresh its caches from the replicated index.

This PR also includes the Security-side transport and authorization support needed for actual CCR replication of `.opendistro_security`. CCR bootstrap restore can create the follower shard before the security config documents are available; the documents may arrive through CCR replay shortly afterward. Security therefore needs a narrow pre-initialization path for both CCR restore and CCR replay so the replicated config can land before Security has initialized.

**What standby mode does:**
- **Blocks security config mutation APIs** (PUT/POST/PATCH/DELETE to `/_plugins/_security/api/*`) with a clear 403 response: *"Security configuration is read-only because this cluster is in standby mode."*
- **Allows config reads** (GET requests) — roles, users, etc. can still be queried
- **Skips security index bootstrap/initialization** — the security index is expected to arrive via CCR replication, not be created locally
- **Polls the replicated security index every 5 seconds** to detect changes and refresh auth/authz caches — necessary because CCR-replicated writes don't trigger the normal `ConfigUpdateAction` broadcast
- **Authentication and authorization continue working** using the replicated configuration
- **Allows narrowly scoped CCR restore/replay before Security initialization** only for the exact registered system index marked by CCR
- **Can be toggled dynamically via cluster settings** — standby enforcement paths read the current `plugins.security.standby_mode` value, so a follower cluster can be promoted by disabling standby mode without restarting nodes

**CCR replicated system index handling:**
- CCR marks same-index system-index replication work with thread context: `opensearch.ccr.replicated_system_index = <exact index name>`
- Security preserves that marker across transport using an internal header
- Security only relaxes standby system-index protection when:
  - standby mode is enabled,
  - the CCR marker is present,
  - the request target exactly matches the marker,
  - the target is a registered system index via `SystemIndexRegistry`
- The pre-init path covers:
  - `RestoreSnapshotRequest` for the exact marked registered system index
  - CCR replay action `indices:data/write/plugins/replication/changes` for the exact marked registered system index

This avoids adding a broad allowlist for dot indices or arbitrary system indices. The source of truth remains plugin system-index registration.

**Setting:** `plugins.security.standby_mode` (boolean, default `false`, dynamic, sensitive)

**Promotion workflow:**
1. Stop CCR replication (makes the security index writable)
2. Set `plugins.security.standby_mode: false` via the cluster settings API
3. Security stops standby config polling and resumes normal security-index ownership behavior
4. Security config mutation APIs become available again without a node restart

**Related work:**
- CCR system index restriction removal / companion branch: https://github.com/cwperks/cross-cluster-replication/pull/1
- Upstream CCR PR used as the feature-branch base: https://github.com/opensearch-project/cross-cluster-replication/pull/1667
- Full Cluster Replication RFC: https://github.com/opensearch-project/cross-cluster-replication/issues/762

### Changes

| File | Change |
|---|---|
| `ConfigConstants.java` | New `SECURITY_STANDBY_MODE` constant plus CCR replicated-system-index marker/header constants |
| `StandbyModeSetting.java` | New dynamic setting holder for `plugins.security.standby_mode`, shared by standby enforcement paths |
| `OpenSearchSecurityPlugin.java` | Register dynamic/sensitive setting; register cluster settings listener; pass shared standby setting into Security components |
| `AbstractApiAction.java` | Block mutation requests (non-GET) based on the current standby mode value |
| `SecurityApiDependencies.java` / `SecurityRestApiActions.java` | Wire the shared standby setting into REST API actions |
| `ConfigurationRepository.java` | Skip bootstrap in standby mode; poll replicated security index every 5s; stop polling and resume normal ownership behavior when standby is disabled dynamically |
| `SecurityInterceptor.java` | Preserve CCR replicated-system-index marker across same-node and cross-node transport requests |
| `SecurityRequestHandler.java` | Restore CCR replicated-system-index marker from transport header into thread context |
| `SecurityFilter.java` | Allow narrowly scoped standby CCR restore/replay before Security configuration is initialized, based on the current standby mode value |
| `SystemIndexAccessEvaluator.java` | Legacy evaluator allows marked standby CCR access to registered system indices only, based on the current standby mode value |
| `PrivilegesEvaluatorImpl.java` | Legacy wiring passes `ThreadContext`; next-gen evaluator preserves system-index protections except for marked standby CCR access; both use the current standby mode value |
| `StandbyModeSettingTest.java` | Unit test verifies the standby setting tracks cluster setting updates |
| `ConfigurationRepositoryTest.java` | Unit tests verify dynamic standby mode changes affect security-index initialization behavior |
| `StandbyModeTests.java` | Integration tests: auth works, mutations blocked, reads allowed |
| `StandbyModeCcrSimulationTests.java` | End-to-end test simulating CCR: leader cluster config is copied to standby, standby picks it up via polling, auth works with replicated config |

### Testing

- 8 integration tests across 2 test classes, all passing
- `StandbyModeTests` — single cluster with standby mode enabled, verifies API behavior
- `StandbyModeCcrSimulationTests` — two clusters (leader + standby), simulates CCR by copying security config documents from leader to standby's security index, verifies standby detects and loads the replicated config
- `StandbyModeSettingTest` — verifies `plugins.security.standby_mode` updates are tracked dynamically
- `ConfigurationRepositoryTest` — verifies security-index initialization behavior follows the current standby mode value

Local validation with the companion CCR branch also passed:

```bash
cd /Users/craigperkins/Projects/OpenSearch/security
./gradlew compileJava publishZipToMavenLocal -Dbuild.snapshot=true

cd /Users/craigperkins/Projects/OpenSearch/cross-cluster-replication
./gradlew integTest --tests org.opensearch.replication.integ.rest.SecurityStandbyModeIT -Psecurity=true -PnumNodes=1
```

The CCR integration test verifies actual `.opendistro_security` replication into a standby follower cluster and confirms Security initializes from the replicated config.

Additional focused validation for dynamic standby mode:

```bash
cd /Users/craigperkins/Projects/OpenSearch/security
./gradlew compileJava compileTestJava
./gradlew test --tests org.opensearch.security.setting.StandbyModeSettingTest --tests org.opensearch.security.configuration.ConfigurationRepositoryTest --tests org.opensearch.security.filter.SecurityFilterTests
```

### Future Work

- Replace 5s polling with an index change listener or another direct config-change signal for lower-latency cache refresh
- Promote `standby_mode` to a core cluster-level setting (`cluster.standby_mode`) that all plugins can respect
- Add more plugin system-index coverage once other plugins are validated for standby behavior
- Job Scheduler suppression on standby clusters
- Promotion API / status endpoint
- Active-to-standby failback flow: support and test dynamically enabling standby mode on a cluster that previously owned the security index

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).