### PR TITLE
Add sandbox analytics security test workflow

### DIFF
--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -1,0 +1,104 @@
+name: Sandbox Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  GRADLE_OPTS: -Dhttp.keepAlive=false
+  SECURITY_ADMIN_USER: admin
+  SECURITY_ADMIN_PASSWORD: admin
+
+jobs:
+  analytics-security:
+    name: analytics-security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK for build and test
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Checkout security
+        uses: actions/checkout@v6
+        with:
+          path: security
+
+      - name: Checkout OpenSearch
+        uses: actions/checkout@v6
+        with:
+          repository: opensearch-project/OpenSearch
+          path: OpenSearch
+
+      - name: Publish security plugin to Maven local
+        working-directory: security
+        run: ./gradlew publishPluginZipPublicationToMavenLocal
+
+      - name: Start OpenSearch sandbox cluster
+        working-directory: OpenSearch
+        run: |
+          ./gradlew run \
+            -Dsandbox.enabled=true \
+            -Dtests.jvm.argline='-Dopensearch.experimental.feature.transport.stream.enabled=true' \
+            -PinstalledPlugins="['arrow-base','arrow-flight-rpc','opensearch-security','analytics-engine','parquet-data-format','analytics-backend-datafusion','analytics-backend-lucene','dsl-query-executor','composite-engine','test-ppl-frontend']" \
+            -x javadoc -x test -x missingJavadoc \
+            > ../opensearch-sandbox.log 2>&1 &
+          echo "$!" > ../opensearch-sandbox.pid
+
+      - name: Wait for OpenSearch
+        run: |
+          for attempt in {1..120}; do
+            status=$(curl -k -s -o /tmp/security-role-response.txt -w "%{http_code}" \
+              -u "${SECURITY_ADMIN_USER}:${SECURITY_ADMIN_PASSWORD}" \
+              https://localhost:9200/_plugins/_security/api/roles/all_access || true)
+            if [ "$status" = "200" ]; then
+              exit 0
+            fi
+            sleep 5
+          done
+
+          cat /tmp/security-role-response.txt || true
+          tail -n 200 opensearch-sandbox.log
+          exit 1
+
+      - name: Run sandbox analytics security tests
+        working-directory: security
+        run: |
+          ./gradlew sandboxAnalyticsSecurityTest \
+            -Dtests.rest.cluster=localhost:9200 \
+            -Dtests.cluster=localhost:9200 \
+            -Dtests.clustername=runTask \
+            -Dhttps=true \
+            -Duser="${SECURITY_ADMIN_USER}" \
+            -Dpassword="${SECURITY_ADMIN_PASSWORD}"
+
+      - name: Stop OpenSearch
+        if: always()
+        run: |
+          if [ -f opensearch-sandbox.pid ]; then
+            kill "$(cat opensearch-sandbox.pid)" || true
+          fi
+          pkill -f org.opensearch.bootstrap.OpenSearch || true
+
+      - name: Upload sandbox logs
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: sandbox-analytics-security-logs
+          path: |
+            opensearch-sandbox.log
+            OpenSearch/build/testclusters/runTask-0/logs/
+            security/build/reports/tests/sandboxAnalyticsSecurityTest/

--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install native build dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Checkout security
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -45,12 +45,13 @@ jobs:
 
       - name: Publish security plugin to Maven local
         working-directory: security
-        run: ./gradlew publishPluginZipPublicationToMavenLocal
+        run: ./gradlew -Pcrypto.standard=FIPS-140-3 publishPluginZipPublicationToMavenLocal
 
       - name: Start OpenSearch sandbox cluster
         working-directory: OpenSearch
         run: |
           ./gradlew run \
+            -Pcrypto.standard=FIPS-140-3 \
             -Dsandbox.enabled=true \
             -Dtests.jvm.argline='-Dopensearch.experimental.feature.transport.stream.enabled=true' \
             -PinstalledPlugins="['arrow-base','arrow-flight-rpc','opensearch-security','analytics-engine','parquet-data-format','analytics-backend-datafusion','analytics-backend-lucene','dsl-query-executor','composite-engine','test-ppl-frontend']" \
@@ -78,6 +79,7 @@ jobs:
         working-directory: security
         run: |
           ./gradlew sandboxAnalyticsSecurityTest \
+            -Pcrypto.standard=FIPS-140-3 \
             -Dtests.rest.cluster=localhost:9200 \
             -Dtests.cluster=localhost:9200 \
             -Dtests.clustername=runTask \

--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -47,6 +47,10 @@ jobs:
         working-directory: security
         run: ./gradlew -Pcrypto.standard=FIPS-140-3 publishPluginZipPublicationToMavenLocal
 
+      - name: Build OpenSearch native library
+        working-directory: OpenSearch
+        run: ./gradlew -Pcrypto.standard=FIPS-140-3 -Dsandbox.enabled=true :sandbox:libs:dataformat-native:buildRustLibrary
+
       - name: Start OpenSearch sandbox cluster
         working-directory: OpenSearch
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -915,6 +915,26 @@ integTestRemote.enabled = System.getProperty("tests.rest.cluster") != null
 
 tasks.integTestRemote.finalizedBy(jacocoTestReport) // report is always generated after integration tests run
 
+tasks.register("sandboxAnalyticsSecurityTest", Test) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    systemProperty "tests.security.manager", "false"
+    systemProperty "tests.rest.cluster", System.getProperty("tests.rest.cluster")
+    systemProperty "tests.cluster", System.getProperty("tests.cluster")
+    systemProperty "tests.clustername", System.getProperty("tests.clustername")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+    systemProperty "https", System.getProperty("https")
+    systemProperty "security.enabled", "true"
+
+    filter {
+        includeTestsMatching "org.opensearch.security.sandbox.*IT"
+    }
+}
+
+sandboxAnalyticsSecurityTest.enabled = System.getProperty("tests.rest.cluster") != null
+
 // should be updated appropriately, when we add integTests in future
 integTest.enabled = false
 

--- a/src/test/java/org/opensearch/security/sandbox/SandboxAnalyticsSecurityIT.java
+++ b/src/test/java/org/opensearch/security/sandbox/SandboxAnalyticsSecurityIT.java
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.sandbox;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hc.core5.http.HttpHost;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.client.RestClient;
+import org.opensearch.commons.rest.SecureRestClientBuilder;
+import org.opensearch.security.sanity.tests.SecurityRestTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("unchecked")
+public class SandboxAnalyticsSecurityIT extends SecurityRestTestCase {
+
+    private static final String ALLOWED_INDEX = "movies_allowed";
+    private static final String DENIED_INDEX = "movies_denied";
+    private static final String USER = "movies_reader";
+    private static final String PASSWORD = "myStrongPassword123!";
+    private static final String ROLE = "sandbox_analytics_movies_reader";
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        return true;
+    }
+
+    @Test
+    public void testPplIndexAuthorization() throws Exception {
+        try (RestClient adminClient = basicAdminClient()) {
+            configureLimitedUser(adminClient);
+            createMovieIndex(adminClient, ALLOWED_INDEX);
+            createMovieIndex(adminClient, DENIED_INDEX);
+        }
+
+        try (RestClient limitedClient = limitedClient()) {
+            Map<String, Object> allowed = executePpl(limitedClient, "source = " + ALLOWED_INDEX + " | stats count() as c");
+
+            List<List<Object>> rows = (List<List<Object>>) allowed.get("rows");
+            MatcherAssert.assertThat(rows.size(), is(equalTo(1)));
+            MatcherAssert.assertThat(((Number) rows.get(0).get(0)).intValue(), is(equalTo(2)));
+
+            ResponseException denied = expectThrows(
+                ResponseException.class,
+                () -> executePpl(limitedClient, "source = " + DENIED_INDEX + " | stats count() as c")
+            );
+            MatcherAssert.assertThat(denied.getResponse().getStatusLine().getStatusCode(), is(equalTo(403)));
+        }
+    }
+
+    private void configureLimitedUser(RestClient adminClient) throws Exception {
+        putJson(adminClient, "/_plugins/_security/api/roles/" + ROLE, """
+            {
+              "cluster_permissions": ["cluster:internal/qe/unified_ppl_execute"],
+              "index_permissions": [
+                {
+                  "index_patterns": ["%s"],
+                  "allowed_actions": ["read"]
+                }
+              ],
+              "tenant_permissions": []
+            }
+            """.formatted(ALLOWED_INDEX));
+        putJson(adminClient, "/_plugins/_security/api/internalusers/" + USER, """
+            {
+              "password": "%s",
+              "backend_roles": [],
+              "attributes": {}
+            }
+            """.formatted(PASSWORD));
+        putJson(adminClient, "/_plugins/_security/api/rolesmapping/" + ROLE, """
+            {
+              "users": ["%s"],
+              "backend_roles": [],
+              "hosts": []
+            }
+            """.formatted(USER));
+    }
+
+    private void createMovieIndex(RestClient adminClient, String indexName) throws Exception {
+        ignoreNotFound(adminClient, new Request("DELETE", "/" + indexName));
+
+        putJson(adminClient, "/" + indexName, """
+            {
+              "settings": {
+                "number_of_shards": 1,
+                "number_of_replicas": 0,
+                "index.pluggable.dataformat.enabled": true,
+                "index.pluggable.dataformat": "composite",
+                "index.composite.primary_data_format": "parquet",
+                "index.composite.secondary_data_formats": "lucene"
+              },
+              "mappings": {
+                "properties": {
+                  "title": {
+                    "type": "keyword"
+                  },
+                  "rating": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+            """);
+
+        Request bulk = new Request("POST", "/_bulk");
+        bulk.addParameter("refresh", "true");
+        bulk.setJsonEntity("""
+            {"index":{"_index":"%s","_id":"1"}}
+            {"title":"Alien","rating":5}
+            {"index":{"_index":"%s","_id":"2"}}
+            {"title":"Arrival","rating":4}
+            """.formatted(indexName, indexName));
+        assertOK(adminClient.performRequest(bulk));
+    }
+
+    private Map<String, Object> executePpl(RestClient restClient, String query) throws Exception {
+        Request request = new Request("POST", "/_analytics/ppl");
+        request.setJsonEntity("""
+            {
+              "query": "%s"
+            }
+            """.formatted(query));
+        Response response = restClient.performRequest(request);
+        MatcherAssert.assertThat(response.getStatusLine().getStatusCode(), is(equalTo(200)));
+        return entityAsMap(response);
+    }
+
+    private void putJson(RestClient restClient, String endpoint, String body) throws Exception {
+        Request request = new Request("PUT", endpoint);
+        request.setJsonEntity(body);
+        Response response = restClient.performRequest(request);
+        int statusCode = response.getStatusLine().getStatusCode();
+        MatcherAssert.assertThat(statusCode >= 200 && statusCode < 300, is(true));
+    }
+
+    private void ignoreNotFound(RestClient restClient, Request request) throws Exception {
+        try {
+            restClient.performRequest(request);
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+                throw e;
+            }
+        }
+    }
+
+    private RestClient basicAdminClient() throws Exception {
+        return secureClient(System.getProperty("user"), System.getProperty("password"));
+    }
+
+    private RestClient limitedClient() throws Exception {
+        return secureClient(USER, PASSWORD);
+    }
+
+    private RestClient secureClient(String user, String password) throws Exception {
+        List<HttpHost> hosts = getClusterHosts();
+        boolean https = Boolean.parseBoolean(System.getProperty("https"));
+        return new SecureRestClientBuilder(hosts.toArray(new HttpHost[0]), https, user, password).setSocketTimeout(60000)
+            .setConnectionRequestTimeout(180000)
+            .build();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a focused sandbox analytics security test and CI workflow for the new sandbox query engine path.

From a security configuration perspective, this matters because sandbox analytics introduces a new way for users to execute PPL. Security needs coverage that proves a user can be configured to invoke the PPL endpoint while still being constrained by normal index permissions. This test creates a limited `movies_reader` user, grants the PPL execute cluster permission, grants read access only to `movies_allowed`, and verifies that PPL access to `movies_denied` is rejected.

The regression being covered is user-facing: administrators should be able to grant access to the sandbox analytics endpoint without accidentally granting broad data access.

## CI

Adds a separate `Sandbox Tests` workflow that runs only for `main` branch pushes, pull requests targeting `main`, and manual dispatch.

The workflow:

- checks out this security branch and OpenSearch core,
- installs `protobuf-compiler`, which is required by the Rust/Substrait native build,
- publishes the local security plugin ZIP to Maven local with `-Pcrypto.standard=FIPS-140-3`,
- builds the OpenSearch sandbox native library required by the DataFusion backend,
- starts OpenSearch with security plus the sandbox analytics plugin stack using `-Pcrypto.standard=FIPS-140-3`,
- waits for the security roles API to be ready,
- runs only `sandboxAnalyticsSecurityTest` with `-Pcrypto.standard=FIPS-140-3`.

This keeps the new sandbox coverage isolated from the existing integration-test suites while making the crypto standard explicit in the CI logs.

## How to run locally

From the security repo, publish this branch's plugin ZIP to Maven local:

```bash
cd /Users/craigperkins/Projects/OpenSearch/security
./gradlew -Pcrypto.standard=FIPS-140-3 publishPluginZipPublicationToMavenLocal
```

Then start OpenSearch core with security and the sandbox analytics plugin stack:

```bash
cd /Users/craigperkins/Projects/OpenSearch/OpenSearch
JAVA_HOME=/Users/craigperkins/.sdkman/candidates/java/25.0.2-amzn ./gradlew \
  -Pcrypto.standard=FIPS-140-3 \
  -Dsandbox.enabled=true \
  :sandbox:libs:dataformat-native:buildRustLibrary

JAVA_HOME=/Users/craigperkins/.sdkman/candidates/java/25.0.2-amzn ./gradlew run \
  -Pcrypto.standard=FIPS-140-3 \
  -Dsandbox.enabled=true \
  -Dtests.jvm.argline='-Dopensearch.experimental.feature.transport.stream.enabled=true' \
  -PinstalledPlugins="['arrow-base','arrow-flight-rpc','opensearch-security','analytics-engine','parquet-data-format','analytics-backend-datafusion','analytics-backend-lucene','dsl-query-executor','composite-engine','test-ppl-frontend']" \
  -x javadoc -x test -x missingJavadoc
```

Once the security roles API is ready, run the targeted test from the security repo:

```bash
cd /Users/craigperkins/Projects/OpenSearch/security
./gradlew -Pcrypto.standard=FIPS-140-3 sandboxAnalyticsSecurityTest \
  -Dtests.rest.cluster=localhost:9200 \
  -Dtests.cluster=localhost:9200 \
  -Dtests.clustername=runTask \
  -Dhttps=true \
  -Duser=admin \
  -Dpassword=admin
```

The test currently fails as expected against core without the sandbox analytics authorization fix because the denied-index PPL query succeeds instead of returning `403`.

## Validation

```bash
./gradlew -Pcrypto.standard=FIPS-140-3 spotlessApply
./gradlew compileTestJava
```

Also ran `sandboxAnalyticsSecurityTest` locally against a core sandbox cluster. It reached the expected failing assertion for the missing denied-index authorization.
