### PR TITLE
Apply strict compiler args to integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,59 +91,33 @@ java.sourceCompatibility = JavaVersion.VERSION_21
 java.targetCompatibility = JavaVersion.VERSION_21
 
 
-compileJava {
-    options.compilerArgs = [
-            '-Xlint:auxiliaryclass',
-            '-Xlint:cast',
-            '-Xlint:classfile',
-            '-Xlint:dep-ann',
-            '-Xlint:divzero',
-            '-Xlint:empty',
-            '-Xlint:exports',
-            '-Xlint:fallthrough',
-            '-Xlint:finally',
-            '-Xlint:module',
-            '-Xlint:opens',
-            '-Xlint:overloads',
-            '-Xlint:overrides',
-            '-Xlint:-processing',
-            '-Xlint:rawtypes',
-            '-Xlint:removal',
-            '-Xlint:requires-automatic',
-            '-Xlint:requires-transitive-automatic',
-            '-Xlint:static',
-            '-Xlint:unchecked',
-            '-Xlint:varargs',
-            '-Xlint:preview',
-            '-Werror']
-    options.encoding = 'UTF-8'
-}
+def strictJavaCompilerArgs = [
+        '-Xlint:auxiliaryclass',
+        '-Xlint:cast',
+        '-Xlint:classfile',
+        '-Xlint:dep-ann',
+        '-Xlint:divzero',
+        '-Xlint:empty',
+        '-Xlint:exports',
+        '-Xlint:fallthrough',
+        '-Xlint:finally',
+        '-Xlint:module',
+        '-Xlint:opens',
+        '-Xlint:overloads',
+        '-Xlint:overrides',
+        '-Xlint:-processing',
+        '-Xlint:rawtypes',
+        '-Xlint:removal',
+        '-Xlint:requires-automatic',
+        '-Xlint:requires-transitive-automatic',
+        '-Xlint:static',
+        '-Xlint:unchecked',
+        '-Xlint:varargs',
+        '-Xlint:preview',
+        '-Werror']
 
-compileTestJava {
-    options.compilerArgs = [
-            '-Xlint:auxiliaryclass',
-            '-Xlint:cast',
-            '-Xlint:classfile',
-            '-Xlint:dep-ann',
-            '-Xlint:divzero',
-            '-Xlint:empty',
-            '-Xlint:exports',
-            '-Xlint:fallthrough',
-            '-Xlint:finally',
-            '-Xlint:module',
-            '-Xlint:opens',
-            '-Xlint:overloads',
-            '-Xlint:overrides',
-            '-Xlint:-processing',
-            '-Xlint:rawtypes',
-            '-Xlint:removal',
-            '-Xlint:requires-automatic',
-            '-Xlint:requires-transitive-automatic',
-            '-Xlint:static',
-            '-Xlint:unchecked',
-            '-Xlint:varargs',
-            '-Xlint:preview',
-            '-Werror']
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs = strictJavaCompilerArgs
     options.encoding = 'UTF-8'
 }
 

--- a/src/integrationTest/java/org/opensearch/security/AbstractDefaultConfigurationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/AbstractDefaultConfigurationTests.java
@@ -53,6 +53,7 @@ public abstract class AbstractDefaultConfigurationTests {
             client.confirmCorrectCredentials(ADMIN_USER.getName());
             TestRestClient.HttpResponse response = client.get("_plugins/_security/api/internalusers");
             response.assertStatusCode(HttpStatus.SC_OK);
+            @SuppressWarnings("unchecked")
             Map<String, Object> users = response.getBodyAs(Map.class);
             assertThat(
                 response.getBody(),

--- a/src/integrationTest/java/org/opensearch/security/SecurityConfigurationBootstrapTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityConfigurationBootstrapTests.java
@@ -116,7 +116,7 @@ public class SecurityConfigurationBootstrapTests {
                     cluster.getInternalNodeClient(),
                     Map.of(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true")
                 );
-                final var filesToUpload = ImmutableMap.<String, CType>builder()
+                final var filesToUpload = ImmutableMap.<String, CType<?>>builder()
                     .put("action_groups.yml", CType.ACTIONGROUPS)
                     .put("config.yml", CType.CONFIG)
                     .put("roles.yml", CType.ROLES)

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
@@ -64,7 +64,7 @@ class JwtAuthorizationHeaderFactory {
     }
 
     private Map<String, Object> customClaimsMap(String username, String[] roles) {
-        ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder();
+        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
         // Handle username claim
         if (StringUtils.isNoneEmpty(username)) {
             if (usernameClaimName.size() == 1) {

--- a/src/integrationTest/java/org/opensearch/test/framework/AsyncActions.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/AsyncActions.java
@@ -51,7 +51,7 @@ public class AsyncActions {
     public static <T> List<T> getAll(final List<CompletableFuture<T>> futures, final int n, final TimeUnit unit) {
         LOG.info("Starting to wait for " + futures.size() + " futures to complete in " + unit.toSeconds(n) + " seconds.");
         final long startTimeMs = System.currentTimeMillis();
-        final CompletableFuture<Void> futuresCompleted = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        final CompletableFuture<Void> futuresCompleted = CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
         try {
             futuresCompleted.get(n, unit);
         } catch (final Exception ex) {

--- a/src/integrationTest/java/org/opensearch/test/framework/LdapAuthenticationConfigBuilder.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/LdapAuthenticationConfigBuilder.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 *           type so that all method defined in subclass are available in one of builder superclass method is invoked. Please see
 *           {@link LdapAuthorizationConfigBuilder}
 */
-public class LdapAuthenticationConfigBuilder<T extends LdapAuthenticationConfigBuilder> {
+public class LdapAuthenticationConfigBuilder<T extends LdapAuthenticationConfigBuilder<T>> {
     private boolean enableSsl = false;
     private boolean enableStartTls = false;
     private boolean enableSslClientAuth = false;
@@ -38,12 +38,18 @@ public class LdapAuthenticationConfigBuilder<T extends LdapAuthenticationConfigB
     */
     private final T builderSubclass;
 
-    protected LdapAuthenticationConfigBuilder(Function<LdapAuthenticationConfigBuilder, T> thisCastFunction) {
+    protected LdapAuthenticationConfigBuilder(Function<LdapAuthenticationConfigBuilder<T>, T> thisCastFunction) {
         this.builderSubclass = thisCastFunction.apply(this);
     }
 
-    public static LdapAuthenticationConfigBuilder<LdapAuthenticationConfigBuilder> config() {
-        return new LdapAuthenticationConfigBuilder<>(Function.identity());
+    public static LdapAuthenticationConfigBuilder<?> config() {
+        return new RootLdapAuthenticationConfigBuilder();
+    }
+
+    private static class RootLdapAuthenticationConfigBuilder extends LdapAuthenticationConfigBuilder<RootLdapAuthenticationConfigBuilder> {
+        RootLdapAuthenticationConfigBuilder() {
+            super(RootLdapAuthenticationConfigBuilder.class::cast);
+        }
     }
 
     public T enableSsl(boolean enableSsl) {

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -1151,7 +1151,7 @@ public class TestSecurityConfig {
         public static class HttpAuthenticator implements ToXContentObject {
             private final String type;
             private boolean challenge;
-            private Map<String, Object> config = new HashMap();
+            private Map<String, Object> config = new HashMap<>();
 
             public HttpAuthenticator(String type) {
                 this.type = type;
@@ -1182,7 +1182,7 @@ public class TestSecurityConfig {
 
         public static class AuthenticationBackend implements ToXContentObject {
             private final String type;
-            private Supplier<Map<String, Object>> config = () -> new HashMap();
+            private Supplier<Map<String, Object>> config = HashMap::new;
 
             public AuthenticationBackend(String type) {
                 this.type = type;

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/ClusterManager.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/ClusterManager.java
@@ -161,8 +161,12 @@ public enum ClusterManager {
             }
         }
 
-        private List<Class<? extends Plugin>> mergePlugins(Collection<Class<? extends Plugin>>... plugins) {
-            List<Class<? extends Plugin>> mergedPlugins = Arrays.stream(plugins)
+        private List<Class<? extends Plugin>> mergePlugins(
+            Collection<Class<? extends Plugin>> plugins,
+            Collection<Class<? extends Plugin>> additionalPlugins
+        ) {
+            List<Class<? extends Plugin>> mergedPlugins = Arrays.asList(plugins, additionalPlugins)
+                .stream()
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
@@ -171,7 +175,7 @@ public enum ClusterManager {
 
         @SuppressWarnings("unchecked")
         public Class<? extends Plugin>[] getPlugins() {
-            return plugins.toArray(new Class[0]);
+            return plugins.toArray(Class[]::new);
         }
 
         public Collection<Class<? extends Plugin>> pluginsWithAddition(List<Class<? extends Plugin>> additionalPlugins) {

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
@@ -359,10 +359,10 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         }
     }
 
-    public void triggerConfigurationReloadForCTypes(Client client, List<CType> cTypes, boolean ignoreFailures) {
+    public void triggerConfigurationReloadForCTypes(Client client, List<CType<?>> cTypes, boolean ignoreFailures) {
         ConfigUpdateResponse configUpdateResponse = client.execute(
             ConfigUpdateAction.INSTANCE,
-            new ConfigUpdateRequest(cTypes.stream().map(CType::toLCString).toArray(String[]::new))
+            new ConfigUpdateRequest(cTypes.stream().map(cType -> cType.toLCString()).toArray(String[]::new))
         ).actionGet();
         if (!ignoreFailures && configUpdateResponse.hasFailures()) {
             throw new RuntimeException("ConfigUpdateResponse produced failures: " + configUpdateResponse.failures());
@@ -491,7 +491,9 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
          */
         @SafeVarargs
         public final Builder plugin(Class<? extends Plugin>... plugins) {
-            this.plugins.addAll(List.of(plugins));
+            for (Class<? extends Plugin> plugin : plugins) {
+                this.plugins.add(plugin);
+            }
 
             return this;
         }
@@ -499,7 +501,6 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         /**
          * Adds additional plugins to the cluster
          */
-        @SafeVarargs
         public final Builder plugin(PluginInfo... plugins) {
             this.additionalPlugins.addAll(List.of(plugins));
 

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -325,7 +325,7 @@ public class LocalOpenSearchCluster {
             Node node = new Node(nodeCounter.getAndIncrement(), nodeSettings, transportPortIterator.next(), httpPortIterator.next());
             futures.add(node.start());
         }
-        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
     public void waitForCluster(ClusterHealthStatus status, TimeValue timeout, int expectedNodeCount) throws IOException {

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/SearchResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/SearchResponseMatchers.java
@@ -9,7 +9,7 @@
 */
 package org.opensearch.test.framework.matcher;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -78,8 +78,13 @@ public class SearchResponseMatchers {
         return new SearchHitsContainDocumentsInAnyOrderMatcher(documentIds);
     }
 
+    @SafeVarargs
     public static Matcher<SearchResponse> searchHitsContainDocumentsInAnyOrder(Pair<String, String>... documentIds) {
-        return new SearchHitsContainDocumentsInAnyOrderMatcher(Arrays.asList(documentIds));
+        List<Pair<String, String>> documentIdList = new ArrayList<>();
+        for (Pair<String, String> documentId : documentIds) {
+            documentIdList.add(documentId);
+        }
+        return new SearchHitsContainDocumentsInAnyOrderMatcher(documentIdList);
     }
 
     static Long readTotalHits(SearchResponse searchResponse) {


### PR DESCRIPTION
## What changed

This defines one shared strict Java compiler argument list and applies it to every `JavaCompile` task with `tasks.withType(JavaCompile).configureEach`.

To make that pass for the root `integrationTest` source set, this also cleans up the existing integration-test warnings instead of weakening compiler settings. The fixes are limited to test support code and integration tests:

- replace raw collection and builder usage with typed variants
- avoid generic varargs warnings in test helpers
- tighten LDAP config builder generics
- type `CType` usages with wildcards where needed
- keep one local unchecked cast suppression around the REST response map conversion

## Why

The previous compiler arg cleanup only covered selected Java compile tasks. Applying the same checks through `JavaCompile` task configuration keeps current and future Java source sets consistent and prevents integration-test-only warnings from accumulating unnoticed.

## Validation

- `./gradlew compileJava compileTestJava compileIntegrationTestJava`
- `./gradlew spotlessApply`
- `./gradlew compileJava compileTestJava compileIntegrationTestJava`