### PR TITLE
Migrate AuditConfigMigrater and Hasher CLIs to picocli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -683,6 +683,7 @@ dependencies {
     implementation libs.google.guava
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.11.0'
+    implementation 'info.picocli:picocli:4.7.6'
     // When building with crypto.standard=FIPS-140-3 (set in gradle.properties), bcFips jars are provided by OpenSearch
     if (FipsBuildParams.isInFipsMode()) {
         compileOnly "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
@@ -995,4 +996,19 @@ tasks.register("updateVersion") {
         }
         ant.replaceregexp(file: 'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags: 'g', byline: true)
     }
+}
+
+// Helper task to run CLI tools: ./gradlew runTool -PtoolClass=org.opensearch.security.tools.Hasher -PtoolArgs="--help"
+configurations {
+    toolRuntime {
+        extendsFrom implementation, compileOnly
+        canBeResolved = true
+    }
+}
+tasks.register('runTool', JavaExec) {
+    classpath = sourceSets.main.output + configurations.toolRuntime
+    mainClass = project.findProperty('toolClass') ?: 'org.opensearch.security.tools.Hasher'
+    args = (project.findProperty('toolArgs') ?: '--help').split(' ').toList()
+    jvmArgs = ['--add-opens=java.base/java.lang=ALL-UNNAMED']
+    ignoreExitValue = true
 }

--- a/src/main/java/org/opensearch/security/tools/AuditConfigMigrater.java
+++ b/src/main/java/org/opensearch/security/tools/AuditConfigMigrater.java
@@ -18,12 +18,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
@@ -32,67 +26,61 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.config.AuditConfig;
 
-public class AuditConfigMigrater {
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "audit_config_migrater.sh", mixinStandardHelpOptions = true, description = "Migrates audit configuration from opensearch.yml to audit.yml format.",
+    header = {
+        "",
+        "@|cyan    ___                   ____                      _  |@",
+        "@|cyan   / _ \\ _ __   ___ _ __ / ___|  ___  __ _ _ __ ___| |__ |@",
+        "@|cyan  | | | | '_ \\ / _ \\ '_ \\\\___ \\ / _ \\/ _` | '__/ __| '_ \\|@",
+        "@|cyan  | |_| | |_) |  __/ | | |___) |  __/ (_| | | | (__| | | ||@",
+        "@|cyan   \\___/| .__/ \\___|_| |_|____/ \\___|\\__,_|_|  \\___|_| |_||@",
+        "@|cyan        |_||@                @|bold,yellow Security Tools|@",
+        ""
+    })
+public class AuditConfigMigrater implements Runnable {
 
     private static final String AUDIT_YML = "audit.yml";
     private static final String OPENSEARCH_YML = "opensearch.yml";
     private static final String OPENSEARCH_AUDIT_FILTERED_YML = "opensearch.audit-filtered.yml";
     private static final String OPENSEARCH_PATH_CONF_ENV = "OPENSEARCH_PATH_CONF";
 
-    private static final Options options = new Options();
-    private static final HelpFormatter formatter = new HelpFormatter();
-    private static final CommandLineParser parser = new DefaultParser();
+    @Option(names = "-s", paramLabel = "<source>", description = "Path to opensearch.yml file to migrate. If not specified, will try to lookup env OPENSEARCH_PATH_CONF followed by lookup in current directory.")
+    private String source;
+
+    @Option(names = "-oad", paramLabel = "<output-audit-dir>", description = "Output directory to store the generated audit.yml file.")
+    private String outputAuditDir;
+
+    @Option(names = "-oed", paramLabel = "<output-opensearch-dir>", description = "Output directory to store the generated opensearch.audit-filtered.yml file.")
+    private String outputOpensearchDir;
 
     public static void main(String[] args) {
-        options.addOption(
-            Option.builder("s")
-                .argName("source")
-                .hasArg()
-                .desc(
-                    "Path to opensearch.yml file to migrate. If not specified, will try to lookup env "
-                        + OPENSEARCH_PATH_CONF_ENV
-                        + " followed by lookup in current directory."
-                )
-                .build()
-        );
-        options.addOption(
-            Option.builder("oad")
-                .argName("output-audit-dir")
-                .hasArg()
-                .desc(
-                    "Output directory to store the generated "
-                        + AUDIT_YML
-                        + " file. To be uploaded in the index, the file must be present in config/opensearch-security/ or use securityadmin tool."
-                )
-                .build()
-        );
-        options.addOption(
-            Option.builder("oed")
-                .argName("output-opensearch-dir")
-                .hasArg()
-                .desc("Output directory to store the generated " + OPENSEARCH_AUDIT_FILTERED_YML + " file.")
-                .build()
-        );
+        int exitCode = new CommandLine(new AuditConfigMigrater()).execute(args);
+        System.exit(exitCode);
+    }
 
+    @Override
+    public void run() {
         try {
-            final CommandLine line = parser.parse(options, args);
-
             // find source path. if not specified, use environment followed by current directory path
             final String opensearchPathConfDirEnv = System.getenv(OPENSEARCH_PATH_CONF_ENV);
             final String opensearchPath = sanitizeFilePath(
                 opensearchPathConfDirEnv != null ? opensearchPathConfDirEnv : ".",
                 OPENSEARCH_YML
             );
-            final String source = line.getOptionValue("s", opensearchPath);
+            final String sourcePath = source != null ? source : opensearchPath;
 
             // audit output directory
-            final String auditOutput = sanitizeFilePath(line.getOptionValue("oad", "."), AUDIT_YML);
+            final String auditOutput = sanitizeFilePath(outputAuditDir != null ? outputAuditDir : ".", AUDIT_YML);
             // opensearch output directory
-            final String opensearchOutput = sanitizeFilePath(line.getOptionValue("oed", "."), OPENSEARCH_AUDIT_FILTERED_YML);
+            final String opensearchOutput = sanitizeFilePath(outputOpensearchDir != null ? outputOpensearchDir : ".", OPENSEARCH_AUDIT_FILTERED_YML);
 
             // create settings builder
-            System.out.println("Using source opensearch.yml file from path " + source);
-            final Settings.Builder settingsBuilder = Settings.builder().loadFromPath(Paths.get(source));
+            System.out.println("Using source opensearch.yml file from path " + sourcePath);
+            final Settings.Builder settingsBuilder = Settings.builder().loadFromPath(Paths.get(sourcePath));
 
             // create audit config
             final Map<String, Object> result = ImmutableMap.of(
@@ -106,7 +94,7 @@ public class AuditConfigMigrater {
             DefaultObjectMapper.yamlMapper().writeValue(new File(auditOutput), result);
 
             // remove all deprecated values opensearch.yml
-            System.out.println("Looking for deprecated keys in " + source);
+            System.out.println("Looking for deprecated keys in " + sourcePath);
             AuditConfig.DEPRECATED_KEYS.forEach(key -> {
                 if (settingsBuilder.get(key) != null) {
                     System.out.println(" " + key);
@@ -132,8 +120,8 @@ public class AuditConfigMigrater {
                     + " Please remove the deprecated keys from your opensearch.yml or replace with the generated file after reviewing."
             );
         } catch (final Exception e) {
-            formatter.printHelp("audit_config_migrater.sh", options, true);
-            System.exit(-1);
+            System.err.println("Error: " + e.getMessage());
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/org/opensearch/security/tools/Hasher.java
+++ b/src/main/java/org/opensearch/security/tools/Hasher.java
@@ -28,91 +28,138 @@ package org.opensearch.security.tools;
 
 import java.io.Console;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.hasher.PasswordHasherFactory;
 import org.opensearch.security.support.ConfigConstants;
 
-public class Hasher {
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
-    private static final String PASSWORD_OPTION = "p";
-    private static final String ENV_OPTION = "env";
-    private static final String ALGORITHM_OPTION = "a";
-    private static final String ROUNDS_OPTION = "r";
-    private static final String FUNCTION_OPTION = "f";
-    private static final String LENGTH_OPTION = "l";
-    private static final String ITERATIONS_OPTION = "i";
-    private static final String MINOR_OPTION = "min";
-    private static final String HELP_OPTION = "h";
+@Command(name = "hash.sh", mixinStandardHelpOptions = true, description = "Hash a password for use in internal_users.yml",
+    header = {
+        "",
+        "@|cyan    ___                   ____                      _  |@",
+        "@|cyan   / _ \\ _ __   ___ _ __ / ___|  ___  __ _ _ __ ___| |__ |@",
+        "@|cyan  | | | | '_ \\ / _ \\ '_ \\\\___ \\ / _ \\/ _` | '__/ __| '_ \\|@",
+        "@|cyan  | |_| | |_) |  __/ | | |___) |  __/ (_| | | | (__| | | ||@",
+        "@|cyan   \\___/| .__/ \\___|_| |_|____/ \\___|\\__,_|_|  \\___|_| |_||@",
+        "@|cyan        |_||@                @|bold,yellow Security Tools|@",
+        ""
+    })
+public class Hasher implements Runnable {
 
-    private static final String MEMORY_OPTION = "m";
-    private static final String PARALLELISM_OPTION = "par";
-    private static final String TYPE_OPTION = "t";
-    private static final String VERSION_OPTION = "v";
+    @Option(names = { "-p", "--password" }, description = "Cleartext password to hash")
+    private String password;
+
+    @Option(names = "-env", description = "Environment variable name to read password from")
+    private String envVar;
+
+    @Option(names = { "-a", "--algorithm" }, description = "Algorithm to use: BCrypt | PBKDF2 | Argon2. Default: BCrypt")
+    private String algorithm;
+
+    @Option(names = { "-r", "--rounds" }, description = "BCrypt rounds (4-31). Default: 12")
+    private Integer rounds;
+
+    @Option(names = { "-min", "--minor" }, description = "BCrypt minor version: A | B | Y. Default: Y")
+    private String minor;
+
+    @Option(names = { "-f", "--function" }, description = "PBKDF2 function: SHA1 | SHA224 | SHA256 | SHA384 | SHA512. Default: SHA256")
+    private String function;
+
+    @Option(names = { "-l", "--length" }, description = "Key length. Default: 256 (PBKDF2), 32 (Argon2)")
+    private Integer length;
+
+    @Option(names = { "-i", "--iterations" }, description = "Iterations. Default: 600000 (PBKDF2), 3 (Argon2)")
+    private Integer iterations;
+
+    @Option(names = { "-m", "--memory" }, description = "Argon2 memory in KiB. Default: 65536")
+    private Integer memory;
+
+    @Option(names = { "-par", "--parallelism" }, description = "Argon2 parallelism. Default: 1")
+    private Integer parallelism;
+
+    @Option(names = { "-t", "--type" }, description = "Argon2 type: argon2i | argon2d | argon2id. Default: argon2id")
+    private String type;
+
+    @Option(names = { "-v", "--version" }, description = "Argon2 version. Default: 19")
+    private String version;
 
     public static void main(final String[] args) {
-        final HelpFormatter formatter = new HelpFormatter();
-        formatter.setOptionComparator(null);
-        Options options = buildOptions();
-        final CommandLineParser parser = new DefaultParser();
+        int exitCode = new CommandLine(new Hasher()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public void run() {
+        CommandLine.Help.Ansi ansi = CommandLine.Help.Ansi.AUTO;
+        System.out.println(ansi.string(
+            "@|cyan    ___                   ____                      _  |@\n"
+            + "@|cyan   / _ \\ _ __   ___ _ __ / ___|  ___  __ _ _ __ ___| |__ |@\n"
+            + "@|cyan  | | | | '_ \\ / _ \\ '_ \\\\___ \\ / _ \\/ _` | '__/ __| '_ \\|@\n"
+            + "@|cyan  | |_| | |_) |  __/ | | |___) |  __/ (_| | | | (__| | | ||@\n"
+            + "@|cyan   \\___/| .__/ \\___|_| |_|____/ \\___|\\__,_|_|  \\___|_| |_||@\n"
+            + "@|cyan        |_||@                @|bold,yellow Security Tools|@\n"
+        ));
         try {
-            final CommandLine line = parser.parse(options, args);
-            final char[] password;
-
-            if (line.hasOption(HELP_OPTION)) {
-                formatter.printHelp("hash.sh", options, true);
-                System.exit(0);
-            }
-
-            if (line.hasOption(PASSWORD_OPTION)) {
-                password = line.getOptionValue(PASSWORD_OPTION).toCharArray();
-            } else if (line.hasOption(ENV_OPTION)) {
-                final String pwd = System.getenv(line.getOptionValue(ENV_OPTION));
-                if (pwd == null || pwd.isEmpty()) {
-                    throw new Exception("No environment variable '" + line.getOptionValue(ENV_OPTION) + "' set");
-                }
-                password = pwd.toCharArray();
+            final char[] pwd = resolvePassword();
+            if (algorithm != null) {
+                System.out.println(hash(pwd, buildSettings()));
             } else {
-                final Console console = System.console();
-                if (console == null) {
-                    throw new Exception("Cannot allocate a console");
-                }
-                password = console.readPassword("[%s]", "Password:");
+                System.out.println(hash(pwd));
             }
-            if (line.hasOption(ALGORITHM_OPTION)) {
-                String algorithm = line.getOptionValue(ALGORITHM_OPTION);
-                Settings settings;
-                switch (algorithm.toLowerCase()) {
-                    case ConfigConstants.BCRYPT:
-                        settings = getBCryptSettings(line);
-                        break;
-                    case ConfigConstants.PBKDF2:
-                        settings = getPBKDF2Settings(line);
-                        break;
-                    case ConfigConstants.ARGON2:
-                        settings = getArgon2Settings(line);
-                        break;
-                    default:
-                        throw new Exception("Unsupported hashing algorithm: " + algorithm);
-                }
-                System.out.println(hash(password, settings));
-            } else {
-                System.out.println(hash(password));
-            }
-
-        } catch (final Exception exp) {
-            System.err.println("Parsing failed.  Reason: " + exp.getMessage());
-            formatter.printHelp("hash.sh", options, true);
-            System.exit(-1);
+        } catch (final Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            throw new RuntimeException(e);
         }
+    }
+
+    private char[] resolvePassword() throws Exception {
+        if (password != null) {
+            return password.toCharArray();
+        } else if (envVar != null) {
+            final String pwd = System.getenv(envVar);
+            if (pwd == null || pwd.isEmpty()) {
+                throw new Exception("No environment variable '" + envVar + "' set");
+            }
+            return pwd.toCharArray();
+        } else {
+            final Console console = System.console();
+            if (console == null) {
+                throw new Exception("Cannot allocate a console");
+            }
+            return console.readPassword("[%s]", "Password:");
+        }
+    }
+
+    private Settings buildSettings() throws Exception {
+        Settings.Builder settings = Settings.builder();
+        switch (algorithm.toLowerCase()) {
+            case ConfigConstants.BCRYPT:
+                settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, ConfigConstants.BCRYPT);
+                if (rounds != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_BCRYPT_ROUNDS, rounds);
+                if (minor != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_BCRYPT_MINOR, minor.toUpperCase());
+                break;
+            case ConfigConstants.PBKDF2:
+                settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, ConfigConstants.PBKDF2);
+                if (function != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_PBKDF2_FUNCTION, function);
+                if (length != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_PBKDF2_LENGTH, length);
+                if (iterations != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_PBKDF2_ITERATIONS, iterations);
+                break;
+            case ConfigConstants.ARGON2:
+                settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, ConfigConstants.ARGON2);
+                if (memory != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_MEMORY, memory);
+                if (iterations != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_ITERATIONS, iterations);
+                if (parallelism != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_PARALLELISM, parallelism);
+                if (length != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_LENGTH, length);
+                if (type != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_TYPE, type.toLowerCase());
+                if (version != null) settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_VERSION, Integer.parseInt(version));
+                break;
+            default:
+                throw new Exception("Unsupported hashing algorithm: " + algorithm);
+        }
+        return settings.build();
     }
 
     public static String hash(final char[] clearTextPassword) {
@@ -122,181 +169,5 @@ public class Hasher {
     public static String hash(final char[] clearTextPassword, Settings settings) {
         PasswordHasher passwordHasher = PasswordHasherFactory.createPasswordHasher(settings);
         return passwordHasher.hash(clearTextPassword);
-    }
-
-    private static Settings getBCryptSettings(CommandLine line) throws ParseException {
-        Settings.Builder settings = Settings.builder();
-        settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, ConfigConstants.BCRYPT);
-        if (line.hasOption(ROUNDS_OPTION)) {
-            settings.put(
-                ConfigConstants.SECURITY_PASSWORD_HASHING_BCRYPT_ROUNDS,
-                ((Number) line.getParsedOptionValue(ROUNDS_OPTION)).intValue()
-            );
-        }
-        if (line.hasOption(MINOR_OPTION)) {
-            settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_BCRYPT_MINOR, line.getOptionValue(MINOR_OPTION).toUpperCase());
-        }
-        return settings.build();
-    }
-
-    private static Settings getPBKDF2Settings(CommandLine line) throws ParseException {
-        Settings.Builder settings = Settings.builder();
-        settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, ConfigConstants.PBKDF2);
-        if (line.hasOption(FUNCTION_OPTION)) {
-            settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_PBKDF2_FUNCTION, line.getOptionValue(FUNCTION_OPTION));
-        }
-        if (line.hasOption(LENGTH_OPTION)) {
-            settings.put(
-                ConfigConstants.SECURITY_PASSWORD_HASHING_PBKDF2_LENGTH,
-                ((Number) line.getParsedOptionValue(LENGTH_OPTION)).intValue()
-            );
-        }
-        if (line.hasOption(ITERATIONS_OPTION)) {
-            settings.put(
-                ConfigConstants.SECURITY_PASSWORD_HASHING_PBKDF2_ITERATIONS,
-                ((Number) line.getParsedOptionValue(ITERATIONS_OPTION)).intValue()
-            );
-        }
-        return settings.build();
-    }
-
-    private static Settings getArgon2Settings(CommandLine line) throws ParseException {
-        Settings.Builder settings = Settings.builder();
-        settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, ConfigConstants.ARGON2);
-        if (line.hasOption(MEMORY_OPTION)) {
-            settings.put(
-                ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_MEMORY,
-                ((Number) line.getParsedOptionValue(MEMORY_OPTION)).intValue()
-            );
-        }
-        if (line.hasOption(ITERATIONS_OPTION)) {
-            settings.put(
-                ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_ITERATIONS,
-                ((Number) line.getParsedOptionValue(ITERATIONS_OPTION)).intValue()
-            );
-        }
-        if (line.hasOption(PARALLELISM_OPTION)) {
-            settings.put(
-                ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_PARALLELISM,
-                ((Number) line.getParsedOptionValue(PARALLELISM_OPTION)).intValue()
-            );
-        }
-        if (line.hasOption(LENGTH_OPTION)) {
-            settings.put(
-                ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_LENGTH,
-                ((Number) line.getParsedOptionValue(LENGTH_OPTION)).intValue()
-            );
-        }
-        if (line.hasOption(TYPE_OPTION)) {
-            settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_TYPE, line.getOptionValue(TYPE_OPTION).toLowerCase());
-        }
-        if (line.hasOption(VERSION_OPTION)) {
-            settings.put(ConfigConstants.SECURITY_PASSWORD_HASHING_ARGON2_VERSION, Integer.parseInt(line.getOptionValue(VERSION_OPTION)));
-        }
-        return settings.build();
-    }
-
-    private static Options buildOptions() {
-        final Options options = new Options();
-        options.addOption(Option.builder(HELP_OPTION).longOpt("help").desc("Display the help information").argName("help").build());
-        options.addOption(
-            Option.builder(PASSWORD_OPTION).longOpt("password").argName("password").hasArg().desc("Cleartext password to hash").build()
-        );
-        options.addOption(
-            Option.builder(ENV_OPTION)
-                .argName("Environment variable name")
-                .hasArg()
-                .desc("Environment variable name to read password from")
-                .build()
-        );
-        options.addOption(
-            Option.builder(ALGORITHM_OPTION)
-                .longOpt("algorithm")
-                .argName("hashing algorithm")
-                .hasArg()
-                .desc("Algorithm to use for password hashing. Valid values are: BCrypt | PBKDF2 | Argon2. Default: BCrypt")
-                .build()
-        );
-        options.addOption(
-            Option.builder(ROUNDS_OPTION)
-                .longOpt("rounds")
-                .desc("Number of rounds to use in logarithmic form. Valid values are: 4 to 31. Default: 12")
-                .hasArg()
-                .argName("rounds (BCrypt)")
-                .type(Number.class)
-                .build()
-        );
-        options.addOption(
-            Option.builder(MINOR_OPTION)
-                .longOpt("minor")
-                .desc("Version of BCrypt algorithm to use. Valid values are: A | B | Y. Default: Y")
-                .hasArg()
-                .argName("minor (BCrypt)")
-                .build()
-        );
-        options.addOption(
-            Option.builder(LENGTH_OPTION)
-                .longOpt("length")
-                .desc("Desired length of the final derived key. Default: 256 (PKBDF2), 32 (Argon2)")
-                .hasArg()
-                .argName("length (PBKDF2/Argon2)")
-                .type(Number.class)
-                .build()
-        );
-        options.addOption(
-            Option.builder(FUNCTION_OPTION)
-                .longOpt("function")
-                .desc(
-                    "Pseudo-random function applied to the password. Valid values are SHA1 | SHA224 | SHA256 | SHA384 | SHA512. Default: SHA256"
-                )
-                .hasArg()
-                .argName("function (PBDKF2)")
-                .build()
-        );
-        options.addOption(
-            Option.builder(ITERATIONS_OPTION)
-                .longOpt("iterations")
-                .desc("Number of times the pseudo-random function is applied to the password. Default: 600000 (PBKDF2), 3 (Argon2)")
-                .hasArg()
-                .argName("iterations (PBKDF2/Argon2)")
-                .type(Number.class)
-                .build()
-        );
-        options.addOption(
-            Option.builder(MEMORY_OPTION)
-                .longOpt("memory")
-                .desc("Amount of memory to use for Argon2 hashing in KiB. Default: 65536")
-                .hasArg()
-                .argName("memory (Argon2)")
-                .type(Number.class)
-                .build()
-        );
-        options.addOption(
-            Option.builder(PARALLELISM_OPTION)
-                .longOpt("parallelism")
-                .desc("Number of parallel threads to use for Argon2 hashing. Default: 1")
-                .hasArg()
-                .argName("parallelism (Argon2)")
-                .type(Number.class)
-                .build()
-        );
-        options.addOption(
-            Option.builder(TYPE_OPTION)
-                .longOpt("type")
-                .desc("Type of Argon2 algorithm to use. Valid values are: argon2i | argon2d | argon2id. Default: argon2id")
-                .hasArg()
-                .argName("type (Argon2)")
-                .build()
-        );
-        options.addOption(
-            Option.builder(VERSION_OPTION)
-                .longOpt("version")
-                .desc("Version of Argon2 algorithm to use. Default: 19")
-                .hasArg()
-                .argName("version (Argon2)")
-                .type(String.class)
-                .build()
-        );
-        return options;
     }
 }


### PR DESCRIPTION
### Description

Migrates the `AuditConfigMigrater` and `Hasher` CLI tools from manual argument parsing to picocli, improving maintainability and providing better CLI UX (help text, validation, etc.).

### Changes
- Added picocli dependency to `build.gradle`
- Refactored `AuditConfigMigrater` to use picocli annotations
- Refactored `Hasher` to use picocli annotations

### Testing
- Verified CLI tools function correctly with picocli argument parsing