### PR TITLE
Prototype: Standalone audit logging independent of security mode

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DisabledModeAuditLoggingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DisabledModeAuditLoggingTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.audit.AuditLogsRule;
+import org.opensearch.test.framework.audit.TestRuleAuditLogSink;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+/**
+ * Integration test verifying that standalone audit logging works in disabled mode
+ * (security plugin installed but fully disabled).
+ */
+public class DisabledModeAuditLoggingTests {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(
+            Map.of(
+                "plugins.security.disabled",
+                true,
+                "plugins.security.ssl.http.enabled",
+                false,
+                ConfigConstants.SECURITY_AUDIT_STANDALONE_ENABLED,
+                true,
+                "plugins.security.audit.type",
+                TestRuleAuditLogSink.class.getName(),
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
+                Collections.emptyList(),
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
+                Collections.emptyList()
+            )
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .build();
+
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
+
+    @Test
+    public void shouldAuditRestRequestsInDisabledMode() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            HttpResponse response = client.get("_cat/indices");
+            response.assertStatusCode(200);
+        }
+
+        auditLogsRule.assertAtLeast(1, msg -> msg.getCategory() == AuditCategory.GRANTED_PRIVILEGES);
+    }
+
+    @Test
+    public void shouldAuditSearchRequestsInDisabledMode() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            HttpResponse response = client.get("_search");
+            response.assertStatusCode(200);
+        }
+
+        auditLogsRule.assertAtLeast(1, msg -> msg.getCategory() == AuditCategory.GRANTED_PRIVILEGES);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditLoggingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditLoggingTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.audit.AuditLogsRule;
+import org.opensearch.test.framework.audit.TestRuleAuditLogSink;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+/**
+ * Integration tests verifying that standalone audit logging works in non-FGAC modes.
+ */
+public class StandaloneAuditLoggingTests {
+
+    /**
+     * Cluster running in SSL-only mode with standalone audit enabled.
+     */
+    @ClassRule
+    public static LocalCluster sslOnlyCluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(
+            Map.of(
+                ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_STANDALONE_ENABLED,
+                true,
+                "plugins.security.audit.type",
+                TestRuleAuditLogSink.class.getName(),
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
+                Collections.emptyList(),
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
+                Collections.emptyList()
+            )
+        )
+        .sslOnly(true)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .build();
+
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
+
+    @Test
+    public void shouldAuditRestRequestsInSslOnlyMode() {
+        try (TestRestClient client = sslOnlyCluster.getRestClient()) {
+            HttpResponse response = client.get("_cat/indices");
+            response.assertStatusCode(200);
+        }
+
+        auditLogsRule.assertAtLeast(1, msg -> msg.getCategory() == AuditCategory.GRANTED_PRIVILEGES);
+    }
+
+    @Test
+    public void shouldAuditSearchRequestsInSslOnlyMode() {
+        try (TestRestClient client = sslOnlyCluster.getRestClient()) {
+            HttpResponse response = client.get("_search");
+            response.assertStatusCode(200);
+        }
+
+        auditLogsRule.assertAtLeast(1, msg -> msg.getCategory() == AuditCategory.GRANTED_PRIVILEGES);
+    }
+}

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -146,7 +146,9 @@ import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auditlog.AuditLog.Origin;
 import org.opensearch.security.auditlog.AuditLogSslExceptionHandler;
 import org.opensearch.security.auditlog.NullAuditLog;
+import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.auditlog.config.AuditConfig.Filter.FilterEntries;
+import org.opensearch.security.auditlog.filter.AuditActionFilter;
 import org.opensearch.security.auditlog.impl.AuditLogImpl;
 import org.opensearch.security.auth.BackendRegistry;
 import org.opensearch.security.auth.RolesInjector;
@@ -299,6 +301,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     private volatile DynamicConfigFactory dcf;
     private final List<String> demoCertHashes = new ArrayList<String>(3);
     private volatile SecurityFilter sf;
+    private volatile AuditActionFilter auditActionFilter;
     private final AtomicReference<NamedXContentRegistry> namedXContentRegistry = new AtomicReference<>(NamedXContentRegistry.EMPTY);;
     private volatile DlsFlsRequestValve dlsFlsValve = null;
     private final OpensearchDynamicSetting<Boolean> transportPassiveAuthSetting;
@@ -343,6 +346,42 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
     private static boolean isDisabled(final Settings settings) {
         return settings.getAsBoolean(ConfigConstants.SECURITY_DISABLED, false);
+    }
+
+    private static boolean isStandaloneAuditEnabled(final Settings settings) {
+        return settings != null && settings.getAsBoolean(ConfigConstants.SECURITY_AUDIT_STANDALONE_ENABLED, false);
+    }
+
+    private void initStandaloneAuditIfEnabled(
+        Client localClient,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        Environment environment
+    ) {
+        final Settings effectiveSettings = this.settings != null ? this.settings : environment.settings();
+        if (isStandaloneAuditEnabled(effectiveSettings)) {
+            this.threadPool = threadPool;
+            this.cs = clusterService;
+            this.localClient = localClient;
+            final IndexNameExpressionResolver resolver = new IndexNameExpressionResolver(threadPool.getThreadContext());
+            UserFactory userFactory = new UserFactory.Simple();
+            auditLog = new AuditLogImpl(
+                effectiveSettings,
+                configPath,
+                localClient,
+                threadPool,
+                resolver,
+                clusterService,
+                environment,
+                userFactory
+            );
+            auditLog.setConfig(AuditConfig.from(effectiveSettings));
+            sslExceptionHandler = new AuditLogSslExceptionHandler(auditLog);
+            auditActionFilter = new AuditActionFilter(auditLog, threadPool);
+            log.info("Standalone audit logging enabled");
+        } else {
+            auditLog = new NullAuditLog();
+        }
     }
 
     private static boolean useClusterStateToInitSecurityConfig(final Settings settings) {
@@ -966,6 +1005,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         List<ActionFilter> filters = new ArrayList<>(1);
         if (!client && !disabled && !SSLConfig.isSslOnlyMode()) {
             filters.add(Objects.requireNonNull(sf));
+        } else if (auditActionFilter != null) {
+            filters.add(auditActionFilter);
         }
         return filters;
     }
@@ -1179,6 +1220,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     ) {
         SSLConfig.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
         if (SSLConfig.isSslOnlyMode()) {
+            initStandaloneAuditIfEnabled(localClient, clusterService, threadPool, environment);
+
             return super.createComponents(
                 localClient,
                 clusterService,
@@ -1201,6 +1244,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         final List<Object> components = new ArrayList<Object>();
 
         if (client || disabled) {
+            if (disabled) {
+                initStandaloneAuditIfEnabled(localClient, clusterService, threadPool, environment);
+            }
             return components;
         }
 
@@ -1462,6 +1508,31 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         settings.addAll(super.getSettings());
 
         settings.add(Setting.boolSetting(ConfigConstants.SECURITY_SSL_ONLY, false, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.boolSetting(ConfigConstants.SECURITY_AUDIT_STANDALONE_ENABLED, false, Property.NodeScope, Property.Filtered));
+
+        // Audit settings needed in SSL-only mode when audit is enabled
+        settings.add(Setting.simpleString(ConfigConstants.SECURITY_AUDIT_TYPE_DEFAULT, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.intSetting(ConfigConstants.SECURITY_AUDIT_THREADPOOL_SIZE, 10, Property.NodeScope, Property.Filtered));
+        settings.add(
+            Setting.intSetting(ConfigConstants.SECURITY_AUDIT_THREADPOOL_MAX_QUEUE_LEN, 100 * 1000, Property.NodeScope, Property.Filtered)
+        );
+        final List<String> defaultDisabledCategories = List.of("AUTHENTICATED", "GRANTED_PRIVILEGES");
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
+                defaultDisabledCategories,
+                Function.identity(),
+                Property.NodeScope
+            )
+        );
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
+                defaultDisabledCategories,
+                Function.identity(),
+                Property.NodeScope
+            )
+        );
 
         // currently dual mode is supported only when ssl_only is enabled, but this stance would change in future
         settings.add(SecuritySettings.SSL_DUAL_MODE_SETTING);
@@ -1703,18 +1774,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             );
 
             // Security - Audit
-            settings.add(Setting.simpleString(ConfigConstants.SECURITY_AUDIT_TYPE_DEFAULT, Property.NodeScope, Property.Filtered));
             settings.add(Setting.groupSetting(ConfigConstants.SECURITY_AUDIT_CONFIG_ROUTES + ".", Property.NodeScope));
             settings.add(Setting.groupSetting(ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS + ".", Property.NodeScope));
-            settings.add(Setting.intSetting(ConfigConstants.SECURITY_AUDIT_THREADPOOL_SIZE, 10, Property.NodeScope, Property.Filtered));
-            settings.add(
-                Setting.intSetting(
-                    ConfigConstants.SECURITY_AUDIT_THREADPOOL_MAX_QUEUE_LEN,
-                    100 * 1000,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
             settings.add(
                 Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_LOG_REQUEST_BODY, true, Property.NodeScope, Property.Filtered)
             );
@@ -1733,22 +1794,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             final List<String> disabledCategories = new ArrayList<String>(2);
             disabledCategories.add("AUTHENTICATED");
             disabledCategories.add("GRANTED_PRIVILEGES");
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
-                    disabledCategories,
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            ); // not filtered here
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
-                    disabledCategories,
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            ); // not filtered here
             final List<String> ignoredUsers = new ArrayList<String>(2);
             ignoredUsers.add("kibanaserver");
             settings.add(

--- a/src/main/java/org/opensearch/security/auditlog/filter/AuditActionFilter.java
+++ b/src/main/java/org/opensearch/security/auditlog/filter/AuditActionFilter.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.auditlog.filter;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.security.auditlog.AuditLog;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+
+/**
+ * A lightweight ActionFilter that captures transport-layer actions for audit logging
+ * without requiring the full security auth/authz stack. Used in SSL-only mode when
+ * audit logging is enabled.
+ */
+public class AuditActionFilter implements ActionFilter {
+
+    private static final Logger log = LogManager.getLogger(AuditActionFilter.class);
+
+    private final AuditLog auditLog;
+    private final ThreadPool threadPool;
+
+    public AuditActionFilter(AuditLog auditLog, ThreadPool threadPool) {
+        this.auditLog = auditLog;
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    public int order() {
+        return Integer.MIN_VALUE;
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> void apply(
+        Task task,
+        String action,
+        Request request,
+        ActionRequestMetadata<Request, Response> actionRequestMetadata,
+        ActionListener<Response> listener,
+        ActionFilterChain<Request, Response> chain
+    ) {
+        try {
+            // Log the action as a GRANTED_PRIVILEGES event (general request audit)
+            auditLog.logGrantedPrivileges(action, request, task);
+        } catch (Exception e) {
+            log.debug("Failed to log audit event for action {}", action, e);
+        }
+
+        // Always continue the chain — audit-only mode never blocks requests
+        chain.proceed(task, action, request, listener);
+    }
+}

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -324,6 +324,7 @@ public class ConfigConstants {
     public static final String SECURITY_COMPLIANCE_HISTORY_INTERNAL_CONFIG_ENABLED =
         "opendistro_security.compliance.history.internal_config_enabled";
     public static final String SECURITY_SSL_ONLY = SECURITY_SETTINGS_PREFIX + "ssl_only";
+    public static final String SECURITY_AUDIT_STANDALONE_ENABLED = SECURITY_SETTINGS_PREFIX + "audit.standalone_enabled";
     public static final String SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED = "plugins.security_config.ssl_dual_mode_enabled";
     public static final String SECURITY_SSL_DUAL_MODE_SKIP_SECURITY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "passive_security";
     public static final String LEGACY_OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED = "opendistro_security_config.ssl_dual_mode_enabled";


### PR DESCRIPTION
## Why

Today, audit logging only works when the security plugin is running in full FGAC mode. Users running OpenSearch for log analytics, observability, or search without FGAC have zero audit visibility into who is accessing their data. This blocks compliance (SOC2, HIPAA, PCI-DSS, GDPR) for a large segment of users.

This PR prototypes making audit logging a standalone capability that works in every security mode — giving all OpenSearch users the ability to answer "who did what, when?" regardless of their security configuration.

## What

A single new setting (`plugins.security.audit.standalone_enabled`) enables audit logging in non-FGAC modes. The existing audit infrastructure (sinks, routing, config, filtering) works without modification once initialized.

| Mode | Before | After (with `standalone_enabled: true`) |
|------|--------|-----------------------------------------|
| Disabled | No audit | ✅ AuditActionFilter logs all actions |
| SSL-only | No audit | ✅ AuditActionFilter logs all actions |
| FGAC | ✅ SecurityFilter handles audit | Unchanged |

### Configuration

```yaml
plugins.security.audit.standalone_enabled: true
plugins.security.audit.type: log4j  # or internal_opensearch, webhook, etc.
```

## How

The security plugin has 4 gates that prevent audit logging in non-FGAC modes (early returns in `createComponents`, conditional registration in `getActionFilters`, etc.). This PR:

1. **`AuditActionFilter.java`** (new) — Lightweight `ActionFilter` that logs every action and always continues the chain. Unlike `SecurityFilter`, it does no auth — it only observes.

2. **`OpenSearchSecurityPlugin.java`** — New `initStandaloneAuditIfEnabled()` helper initializes `AuditLogImpl` with yml-based config (no security index needed) in non-FGAC paths. Uses `environment.settings()` as fallback when `this.settings` is null (disabled mode). `AuditActionFilter` stored as a volatile field. Essential audit settings moved outside the `!sslOnlyMode` gate.

3. **`ConfigConstants.java`** — New `SECURITY_AUDIT_STANDALONE_ENABLED` constant.

4. **`SslOnlyAuditLoggingTests.java`** (new) — Integration test spinning up a cluster in SSL-only mode, making REST requests, and asserting audit events are captured.

## Testing

- ✅ `SslOnlyAuditLoggingTests` — end-to-end audit in SSL-only mode
- ✅ `SslOnlyTests` — existing behavior unchanged
- ✅ `SecurityDisabledTests` — disabled mode works (uses `environment.settings()` fallback)
- ✅ `ApiTokenAuditTest` — FGAC audit unchanged
- ✅ All audit unit tests
- ✅ Spotless applied

## Known limitations (for intern to address)

1. **Event category** — Uses `GRANTED_PRIVILEGES` as a workaround. A new category (e.g., `REQUEST_AUDIT`) should be defined without auth semantics.
2. **`logIndexEvent()` too narrow** — Only captures `indices:admin/*`. The new category should capture all actions.

## Related

- [Intern Project Scope Doc](https://quip-amazon.com/1bAsAUjYd2EJ/OpenSearch-Audit-Logging-Intern-Project-Summer-2026)
- [Proposal: Standalone Audit Logging Plugin (#501)](https://github.com/opensearch-project/.github/issues/501)
- [Repository Request: opensearch-audit-logging (#502)](https://github.com/opensearch-project/.github/issues/502)