### PR TITLE
Enforce tenant isolation for m* actions on concrete tenant indices

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
@@ -959,6 +959,50 @@ public class DashboardMultiTenancyIntTests {
         this.clusterConfig = clusterConfig;
     }
 
+    @Test
+    public void mget_concreteIndexWithoutTenantHeader_shouldBeDenied() {
+        try (TestRestClient restClient = cluster.getRestClient(user)) {
+            String docId = dashboards_index_human_resources.anyDocument().id();
+
+            TestRestClient.HttpResponse response = restClient.postJson("_mget/?pretty", """
+                {
+                  "docs": [
+                    {
+                      "_index": "%s",
+                      "_id": "%s"
+                    }
+                  ]
+                }
+                """.formatted(dashboards_index_human_resources.name(), docId));
+
+            assertThat(response, isForbidden());
+        }
+    }
+
+    @Test
+    public void msearch_concreteIndexWithoutTenantHeader_shouldBeDenied() {
+        try (TestRestClient restClient = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = restClient.postJson("_msearch", """
+                {"index":"%s"}
+                {"size":10, "query":{"match_all":{}}}
+                """.formatted(dashboards_index_human_resources.name()));
+
+            assertThat(response, isForbidden());
+        }
+    }
+
+    @Test
+    public void bulk_concreteIndexWithoutTenantHeader_shouldBeDenied() {
+        try (TestRestClient restClient = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = restClient.postJson("_bulk", """
+                { "index" : { "_index" : "%s", "_id" : "test_no_header_1" } }
+                { "type": "dashboard", "title": "test" }
+                """.formatted(dashboards_index_human_resources.name()));
+
+            assertThat(response, isForbidden());
+        }
+    }
+
     private void delete(String... paths) {
         try (TestRestClient adminRestClient = cluster.getAdminCertRestClient()) {
             for (String path : paths) {

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
@@ -44,6 +44,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsRequest;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
@@ -346,6 +347,20 @@ public class PrivilegesEvaluatorImpl implements PrivilegesEvaluator {
             // tenants.
             // No further access check for the default tenant is necessary, as access will be also checked on the TransportShardBulkAction
             // level.
+
+            // Check if the bulk request targets another user's concrete tenant index directly.
+            BulkRequest bulkRequest = (BulkRequest) request;
+            String userTenantPrefix = ".kibana_"
+                + user.getName().hashCode()
+                + "_"
+                + user.getName().toLowerCase().replaceAll("[^a-z0-9]+", "");
+            for (DocWriteRequest<?> docRequest : bulkRequest.requests()) {
+                String index = docRequest.index();
+                if (index != null && index.startsWith(".kibana_") && !index.startsWith(userTenantPrefix)) {
+                    auditLog.logMissingPrivileges(action0, request, task);
+                    return PrivilegesEvaluatorResponse.insufficient(action0);
+                }
+            }
 
             presponse = actionPrivileges.hasClusterPrivilege(context, action0);
 

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesInterceptor.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesInterceptor.java
@@ -173,6 +173,23 @@ public class PrivilegesInterceptor {
                 return ACCESS_DENIED_REPLACE_RESULT;
             }
 
+            // For multi-document actions (_mget, _bulk, _msearch, _mtv), deny requests that
+            // directly reference another user's concrete tenant index without a securitytenant header.
+            if (!user.getName().equals(dashboardsServerUsername)
+                && !requestedResolved.isLocalAll()
+                && (request instanceof MultiGetRequest
+                    || request instanceof BulkRequest
+                    || request instanceof MultiSearchRequest
+                    || request instanceof MultiTermVectorsRequest)) {
+                final String userTenantIndex = toUserIndexName(dashboardsIndexName, user.getName());
+                final Set<String> indices = requestedResolved.getAllIndices();
+                for (String idx : indices) {
+                    if (idx.startsWith(dashboardsIndexName + "_") && !idx.startsWith(userTenantIndex)) {
+                        return ACCESS_DENIED_REPLACE_RESULT;
+                    }
+                }
+            }
+
             return CONTINUE_EVALUATION_REPLACE_RESULT;
         }
 


### PR DESCRIPTION
### Description

Ensures that m* cluster actions (`_mget`, `_bulk`, `_msearch`, `_mtv`) cannot access another user's concrete tenant index when the `securitytenant` header is omitted.

PR #6202 addressed the case where the `securitytenant` header is present. However, when the header is omitted entirely and the request body references a concrete tenant index (e.g. `.kibana_{hash}_{username}`), the `PrivilegesInterceptor` returned `CONTINUE_EVALUATION` early without checking for cross-tenant access. Additionally, the `BulkRequest` shortcut in `PrivilegesEvaluatorImpl` skipped the interceptor entirely when `requestedTenant` is null.

### Changes

- **`PrivilegesInterceptor.java`** — Added concrete tenant index check in the null-tenant path for multi-document request types. Denies access when the request references another user's tenant index without the `securitytenant` header.
- **`PrivilegesEvaluatorImpl.java`** — Added tenant index check in the `BulkRequest` shortcut path that skips the interceptor when `requestedTenant` is null. Inspects each `DocWriteRequest` for cross-tenant index references.
- **`DashboardMultiTenancyIntTests.java`** — Added integration tests for concrete index access without the `securitytenant` header.

### Testing

- `mget_concreteIndexWithoutTenantHeader_shouldBeDenied`
- `msearch_concreteIndexWithoutTenantHeader_shouldBeDenied`
- `bulk_concreteIndexWithoutTenantHeader_shouldBeDenied`

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.