### PR TITLE
Scale legacy alias resolution

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/IndexResolverReplacerAliasScaleIntegTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/IndexResolverReplacerAliasScaleIntegTests.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.privileges.int_tests;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.data.TestIndex;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
+
+public class IndexResolverReplacerAliasScaleIntegTests {
+
+    private static final int ALIAS_COUNT = 5_000;
+    private static final int EXACT_REQUEST_COUNT = 100;
+    private static final int PREFIX_REQUEST_COUNT = 25;
+    private static final String INDEX = "alias-scale-index";
+    private static final String ALIAS_PREFIX = "alias-scale-";
+
+    private static final TestIndex TEST_INDEX = TestIndex.name(INDEX).documentCount(1).build();
+    private static final TestSecurityConfig.User READER = new TestSecurityConfig.User("alias_scale_reader").roles(
+        new Role("alias_scale_reader_role").indexPermissions("read").on(INDEX, ALIAS_PREFIX + "*")
+    );
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(READER, TestSecurityConfig.User.USER_ADMIN)
+        .indices(TEST_INDEX)
+        .build();
+
+    @BeforeClass
+    public static void createAliasHeavyClusterState() {
+        StringBuilder body = new StringBuilder(ALIAS_COUNT * 80).append("{\"actions\":[");
+        for (int i = 0; i < ALIAS_COUNT; i++) {
+            if (i != 0) {
+                body.append(',');
+            }
+            body.append("{\"add\":{\"index\":\"").append(INDEX).append("\",\"alias\":\"").append(ALIAS_PREFIX).append(i).append("\"}}");
+        }
+        body.append("]}");
+
+        try (TestRestClient adminClient = cluster.getAdminCertRestClient()) {
+            assertThat(adminClient.postJson("_aliases", body.toString()), isOk());
+        }
+    }
+
+    @Test
+    public void repeatedExactConcreteIndexRequestsWithManyAliases() {
+        assertRepeatedSearches(INDEX, EXACT_REQUEST_COUNT);
+    }
+
+    @Test
+    public void repeatedExactAliasRequestsWithManyAliases() {
+        assertRepeatedSearches(ALIAS_PREFIX + (ALIAS_COUNT - 1), EXACT_REQUEST_COUNT);
+    }
+
+    @Test
+    public void repeatedPrefixAliasRequestsWithManyAliases() {
+        assertRepeatedSearches(ALIAS_PREFIX + "49*", PREFIX_REQUEST_COUNT);
+    }
+
+    private static void assertRepeatedSearches(String indexExpression, int requestCount) {
+        try (TestRestClient client = cluster.getRestClient(READER)) {
+            for (int i = 0; i < requestCount; i++) {
+                assertThat("Request " + i + " for " + indexExpression, client.get(indexExpression + "/_search?size=0"), isOk());
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacer.java
@@ -39,6 +39,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.function.Supplier;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -312,15 +313,9 @@ public class IndexResolverReplacer {
                 final Set<String> dateResolvedLocalRequestedPatterns = localRequestedPatterns.stream()
                     .map(resolver::resolveDateMathExpression)
                     .collect(Collectors.toSet());
-                final WildcardMatcher dateResolvedMatcher = WildcardMatcher.from(dateResolvedLocalRequestedPatterns);
                 // fill matchingAliases
-                final Map<String, IndexAbstraction> lookup = state.metadata().getIndicesLookup();
-                matchingAliases = lookup.entrySet()
-                    .stream()
-                    .filter(e -> e.getValue().getType() == ALIAS)
-                    .map(Map.Entry::getKey)
-                    .filter(dateResolvedMatcher)
-                    .collect(Collectors.toSet());
+                final SortedMap<String, IndexAbstraction> lookup = state.metadata().getIndicesLookup();
+                matchingAliases = resolveMatchingAliases(lookup, dateResolvedLocalRequestedPatterns);
 
                 final boolean isDebugEnabled = log.isDebugEnabled();
                 try {
@@ -426,6 +421,49 @@ public class IndexResolverReplacer {
 
             return resolved;
         }
+    }
+
+    static Set<String> resolveMatchingAliases(SortedMap<String, IndexAbstraction> lookup, Set<String> dateResolvedLocalRequestedPatterns) {
+        final Set<String> matchingAliases = new HashSet<>();
+        boolean canUseBoundedLookup = true;
+        for (String pattern : dateResolvedLocalRequestedPatterns) {
+            if (WildcardMatcher.isExact(pattern) == false && WildcardMatcher.isPrefixPattern(pattern) == false) {
+                canUseBoundedLookup = false;
+                break;
+            }
+        }
+
+        if (canUseBoundedLookup) {
+            // The indices lookup is sorted, so exact names and simple prefix patterns do not need to scan the full cluster metadata.
+            for (String pattern : dateResolvedLocalRequestedPatterns) {
+                if (WildcardMatcher.isExact(pattern)) {
+                    final IndexAbstraction indexAbstraction = lookup.get(pattern);
+                    if (indexAbstraction != null && indexAbstraction.getType() == ALIAS) {
+                        matchingAliases.add(pattern);
+                    }
+                } else {
+                    final String prefix = pattern.substring(0, pattern.length() - 1);
+                    final char[] upperBound = prefix.toCharArray();
+                    upperBound[upperBound.length - 1]++;
+                    for (Map.Entry<String, IndexAbstraction> entry : lookup.subMap(prefix, new String(upperBound)).entrySet()) {
+                        if (entry.getValue().getType() == ALIAS) {
+                            matchingAliases.add(entry.getKey());
+                        }
+                    }
+                }
+            }
+
+            return matchingAliases;
+        }
+
+        final WildcardMatcher dateResolvedMatcher = WildcardMatcher.from(dateResolvedLocalRequestedPatterns);
+        lookup.entrySet()
+            .stream()
+            .filter(entry -> entry.getValue().getType() == ALIAS)
+            .map(Map.Entry::getKey)
+            .filter(dateResolvedMatcher)
+            .forEach(matchingAliases::add);
+        return matchingAliases;
     }
 
     // dnfof

--- a/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacerTest.java
+++ b/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacerTest.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.privileges.actionlevel.legacy;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.junit.Test;
+
+import org.opensearch.cluster.metadata.IndexAbstraction;
+import org.opensearch.security.util.MockIndexMetadataBuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IndexResolverReplacerTest {
+
+    private static final int ALIAS_COUNT = 10_000;
+    private static final String INDEX = "alias-scale-index";
+    private static final String ALIAS_PREFIX = "alias-scale-";
+    private static final SortedMap<String, IndexAbstraction> ALIAS_HEAVY_LOOKUP = createAliasHeavyLookup();
+
+    @Test
+    public void exactConcreteIndexDoesNotTraverseAliasLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+
+        assertThat(IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(INDEX)), empty());
+        assertThat(lookup.getCalls, equalTo(1));
+        assertThat(lookup.fullEntrySetCalls, equalTo(0));
+        assertThat(lookup.subMapCalls, equalTo(0));
+    }
+
+    @Test
+    public void exactAliasDoesNotTraverseAliasLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+        String alias = ALIAS_PREFIX + (ALIAS_COUNT - 1);
+
+        assertThat(IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(alias)), containsInAnyOrder(alias));
+        assertThat(lookup.getCalls, equalTo(1));
+        assertThat(lookup.fullEntrySetCalls, equalTo(0));
+        assertThat(lookup.subMapCalls, equalTo(0));
+    }
+
+    @Test
+    public void prefixAliasPatternUsesBoundedLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+
+        assertThat(
+            IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(ALIAS_PREFIX + "999*")),
+            containsInAnyOrder(
+                ALIAS_PREFIX + "999",
+                ALIAS_PREFIX + "9990",
+                ALIAS_PREFIX + "9991",
+                ALIAS_PREFIX + "9992",
+                ALIAS_PREFIX + "9993",
+                ALIAS_PREFIX + "9994",
+                ALIAS_PREFIX + "9995",
+                ALIAS_PREFIX + "9996",
+                ALIAS_PREFIX + "9997",
+                ALIAS_PREFIX + "9998",
+                ALIAS_PREFIX + "9999"
+            )
+        );
+        assertThat(lookup.getCalls, equalTo(0));
+        assertThat(lookup.fullEntrySetCalls, equalTo(0));
+        assertThat(lookup.subMapCalls, equalTo(1));
+        assertThat(lookup.subMapEntryCount, equalTo(11));
+    }
+
+    @Test
+    public void complexAliasPatternFallsBackToFullLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+
+        assertThat(
+            IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(ALIAS_PREFIX + "9?9")),
+            containsInAnyOrder(matchingAliases("9?9").toArray(new String[0]))
+        );
+        assertThat(lookup.fullEntrySetCalls, equalTo(1));
+    }
+
+    private static TrackingSortedMap aliasHeavyLookup() {
+        return new TrackingSortedMap(ALIAS_HEAVY_LOOKUP);
+    }
+
+    private static SortedMap<String, IndexAbstraction> createAliasHeavyLookup() {
+        MockIndexMetadataBuilder builder = MockIndexMetadataBuilder.indices(INDEX);
+        for (int i = 0; i < ALIAS_COUNT; i++) {
+            builder.alias(ALIAS_PREFIX + i).of(INDEX);
+        }
+        return new TreeMap<>(builder.build());
+    }
+
+    private static Collection<String> matchingAliases(String pattern) {
+        return java.util.stream.IntStream.range(0, ALIAS_COUNT)
+            .mapToObj(i -> ALIAS_PREFIX + i)
+            .filter(org.opensearch.security.support.WildcardMatcher.from(ALIAS_PREFIX + pattern))
+            .toList();
+    }
+
+    private static class TrackingSortedMap extends AbstractMap<String, IndexAbstraction> implements SortedMap<String, IndexAbstraction> {
+
+        private final SortedMap<String, IndexAbstraction> delegate;
+        private int getCalls;
+        private int fullEntrySetCalls;
+        private int subMapCalls;
+        private int subMapEntryCount;
+
+        private TrackingSortedMap(SortedMap<String, IndexAbstraction> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public IndexAbstraction get(Object key) {
+            getCalls++;
+            return delegate.get(key);
+        }
+
+        @Override
+        public Set<Entry<String, IndexAbstraction>> entrySet() {
+            fullEntrySetCalls++;
+            return delegate.entrySet();
+        }
+
+        @Override
+        public Comparator<? super String> comparator() {
+            return delegate.comparator();
+        }
+
+        @Override
+        public SortedMap<String, IndexAbstraction> subMap(String fromKey, String toKey) {
+            subMapCalls++;
+            SortedMap<String, IndexAbstraction> result = delegate.subMap(fromKey, toKey);
+            subMapEntryCount += result.size();
+            return result;
+        }
+
+        @Override
+        public SortedMap<String, IndexAbstraction> headMap(String toKey) {
+            return delegate.headMap(toKey);
+        }
+
+        @Override
+        public SortedMap<String, IndexAbstraction> tailMap(String fromKey) {
+            return delegate.tailMap(fromKey);
+        }
+
+        @Override
+        public String firstKey() {
+            return delegate.firstKey();
+        }
+
+        @Override
+        public String lastKey() {
+            return delegate.lastKey();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- avoid traversing every index abstraction when legacy resolution receives exact index or alias names
- use bounded ranges from the sorted index lookup for simple prefix patterns
- preserve the existing full scan for complex wildcard and regex expressions
- cover the behavior with 10,000-alias unit tests and repeated searches against a 5,000-alias integration cluster

## Why

Legacy alias resolution currently scans the complete index lookup for every non-`_all` request. Clusters with thousands of aliases therefore pay that cost even when a request names one concrete index or one exact alias.

The unit tests instrument the sorted lookup and verify that:

- one exact concrete index or alias performs one direct lookup and no full traversal
- `alias-scale-999*` examines the 11 entries in its bounded range rather than all 10,001 index abstractions
- complex patterns continue to use the general full-scan matcher

## Validation

- `./gradlew spotlessApply test --tests 'org.opensearch.security.privileges.actionlevel.legacy.IndexResolverReplacerTest' :precommit`
- `./gradlew :integrationTest --tests 'org.opensearch.security.privileges.int_tests.IndexResolverReplacerAliasScaleIntegTests'`

The integration test passed against a FIPS-140-3 snapshot published locally from current OpenSearch `main` (`1d71f7b4053`).