### PR TITLE
Honor local all-indices request provenance

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
@@ -34,6 +34,7 @@ import org.opensearch.test.framework.matcher.RestIndexMatchers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 import static org.opensearch.test.framework.cluster.TestRestClient.json;
 import static org.opensearch.test.framework.matcher.RestIndexMatchers.OnResponseIndexMatcher.containsExactly;
 import static org.opensearch.test.framework.matcher.RestIndexMatchers.OnUserIndexMatcher.limitedTo;
@@ -47,6 +48,8 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(Parameterized.class)
 public class DashboardMultiTenancyIntTests {
+
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
     // -------------------------------------------------------------------------------------------------------
     // Tenants
@@ -349,6 +352,7 @@ public class DashboardMultiTenancyIntTests {
         return new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
             .authc(AUTHC_HTTPBASIC_INTERNAL)
             .users(USERS)
+            .users(ADMIN_USER)
             .tenants(TENANT_HUMAN_RESOURCES, TENANT_BUSINESS_INTELLIGENCE, TENANT_FINANCE)
             .indices(
                 dashboards_index_global,
@@ -1000,8 +1004,8 @@ public class DashboardMultiTenancyIntTests {
     }
 
     /**
-     * Verifies that the paginated list indices API is not denied when its internal monitor
-     * requests operate on a concrete page that includes dashboards tenant indices.
+     * Verifies that the paginated list indices API preserves the local-all provenance of its
+     * original request when internal monitor requests operate on a concrete page.
      */
     @Test
     public void listIndices_withTenantHeader_shouldNotBeDenied() {
@@ -1010,13 +1014,25 @@ public class DashboardMultiTenancyIntTests {
             return;
         }
 
-        try (TestRestClient restClient = cluster.getRestClient(WILDCARD_TENANT_USER)) {
-            TestRestClient.HttpResponse response = restClient.get(
-                "_list/indices/.kib*",
-                new BasicHeader("securitytenant", "human_resources")
-            );
+        try (TestRestClient restClient = cluster.getRestClient(ADMIN_USER)) {
+            TestRestClient.HttpResponse response = restClient.get("_list/indices", new BasicHeader("securitytenant", "__user__"));
 
             assertThat(response, isOk());
+        }
+    }
+
+    @Test
+    public void monitorActions_directlyTargetingConcreteTenantIndex_shouldBeDenied() {
+        // Only run once (not for every parameterized user)
+        if (!user.equals(WILDCARD_TENANT_USER)) {
+            return;
+        }
+
+        try (TestRestClient restClient = cluster.getRestClient(ADMIN_USER)) {
+            BasicHeader tenantHeader = new BasicHeader("securitytenant", "__user__");
+
+            assertThat(restClient.get(dashboards_index_human_resources.name() + "/_stats", tenantHeader), isForbidden());
+            assertThat(restClient.get("_cluster/health/" + dashboards_index_human_resources.name(), tenantHeader), isForbidden());
         }
     }
 

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacer.java
@@ -603,18 +603,46 @@ public class IndexResolverReplacer {
             Map<String, OriginalIndices> remoteIndicesAsMap,
             IndicesOptions indicesOptions
         ) {
+            this(aliases, allIndices, originalRequested, remoteIndices, remoteIndicesAsMap, indicesOptions, false);
+        }
+
+        private Resolved(
+            final ImmutableSet<String> aliases,
+            final ImmutableSet<String> allIndices,
+            final ImmutableSet<String> originalRequested,
+            final ImmutableSet<String> remoteIndices,
+            Map<String, OriginalIndices> remoteIndicesAsMap,
+            IndicesOptions indicesOptions,
+            boolean forceLocalAll
+        ) {
             this.aliases = aliases;
             this.allIndices = allIndices;
             this.originalRequested = originalRequested;
             this.remoteIndices = remoteIndices;
             this.remoteIndicesAsMap = remoteIndicesAsMap;
-            this.isLocalAll = IndexResolverReplacer.isLocalAll(originalRequested.toArray(new String[0]))
+            this.isLocalAll = forceLocalAll
+                || IndexResolverReplacer.isLocalAll(originalRequested.toArray(new String[0]))
                 || (aliases.contains("*") && allIndices.contains("*"));
             this.indicesOptions = indicesOptions;
         }
 
         public boolean isLocalAll() {
             return isLocalAll;
+        }
+
+        Resolved asLocalAll() {
+            if (isLocalAll) {
+                return this;
+            }
+            return new Resolved(
+                ImmutableSet.copyOf(aliases),
+                ImmutableSet.copyOf(allIndices),
+                All_SET,
+                ImmutableSet.copyOf(remoteIndices),
+                remoteIndicesAsMap,
+                indicesOptions,
+                true
+            );
         }
 
         public Set<String> getAliases() {

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/LocalAllIndicesRequestHelper.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/LocalAllIndicesRequestHelper.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.privileges.actionlevel.legacy;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.admin.cluster.health.ClusterHealthAction;
+import org.opensearch.action.admin.indices.stats.IndicesStatsAction;
+import org.opensearch.action.support.LocalAllIndicesRequest;
+import org.opensearch.action.support.LocalAllIndicesRequestContext;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.security.support.HeaderHelper;
+
+final class LocalAllIndicesRequestHelper {
+
+    private LocalAllIndicesRequestHelper() {}
+
+    static boolean isTrustedLocalAllMonitorRequest(ActionRequest request, String action, ThreadContext threadContext) {
+        final boolean trustedContext = LocalAllIndicesRequestContext.isMarked(threadContext)
+            || HeaderHelper.isInterClusterRequest(threadContext);
+        if (trustedContext == false) {
+            return false;
+        }
+
+        return (IndicesStatsAction.NAME.equals(action)
+            || IndicesStatsAction.NAME.concat("[n]").equals(action)
+            || ClusterHealthAction.NAME.equals(action))
+            && request instanceof LocalAllIndicesRequest
+            && ((LocalAllIndicesRequest) request).isDerivedFromLocalAllIndices();
+    }
+}

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
@@ -360,7 +360,10 @@ public class PrivilegesEvaluatorImpl implements PrivilegesEvaluator {
             return presponse;
         }
 
-        final Resolved requestedResolved = this.irr.resolveRequest(request);
+        Resolved requestedResolved = this.irr.resolveRequest(request);
+        if (LocalAllIndicesRequestHelper.isTrustedLocalAllMonitorRequest(request, action0, threadContext)) {
+            requestedResolved = requestedResolved.asLocalAll();
+        }
 
         log.debug("RequestedResolved : {}", requestedResolved);
 

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesInterceptor.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesInterceptor.java
@@ -24,12 +24,14 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.IndicesRequest.Replaceable;
+import org.opensearch.action.admin.cluster.health.ClusterHealthAction;
 import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsIndexRequest;
 import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
 import org.opensearch.action.admin.indices.refresh.RefreshRequest;
+import org.opensearch.action.admin.indices.stats.IndicesStatsAction;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.get.MultiGetRequest;
@@ -37,6 +39,7 @@ import org.opensearch.action.get.MultiGetRequest.Item;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.LocalAllIndicesRequest;
 import org.opensearch.action.support.replication.ReplicationRequest;
 import org.opensearch.action.support.single.shard.SingleShardRequest;
 import org.opensearch.action.termvectors.MultiTermVectorsRequest;
@@ -241,10 +244,10 @@ public class PrivilegesInterceptor {
             // We check originalRequested (what the user explicitly specified) rather than allIndices
             // (the fully resolved set) to avoid false positives from broad queries like _cat/indices
             // where tenant indices are incidentally included in the resolution.
-            if ((request instanceof BulkRequest
-                || request instanceof MultiGetRequest
-                || request instanceof MultiSearchRequest
-                || request instanceof MultiTermVectorsRequest) && !requestedResolved.isLocalAll()) {
+            final boolean localAllMonitorRequest = request instanceof LocalAllIndicesRequest
+                && ((LocalAllIndicesRequest) request).isDerivedFromLocalAllIndices()
+                && (IndicesStatsAction.NAME.equals(action) || ClusterHealthAction.NAME.equals(action));
+            if (!requestedResolved.isLocalAll() && !localAllMonitorRequest) {
                 final Set<String> originalRequested = requestedResolved.getOriginalRequested();
 
                 for (String idx : originalRequested) {

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesInterceptor.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesInterceptor.java
@@ -24,14 +24,12 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.IndicesRequest.Replaceable;
-import org.opensearch.action.admin.cluster.health.ClusterHealthAction;
 import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsIndexRequest;
 import org.opensearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
 import org.opensearch.action.admin.indices.refresh.RefreshRequest;
-import org.opensearch.action.admin.indices.stats.IndicesStatsAction;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.get.MultiGetRequest;
@@ -39,7 +37,6 @@ import org.opensearch.action.get.MultiGetRequest.Item;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.support.LocalAllIndicesRequest;
 import org.opensearch.action.support.replication.ReplicationRequest;
 import org.opensearch.action.support.single.shard.SingleShardRequest;
 import org.opensearch.action.termvectors.MultiTermVectorsRequest;
@@ -244,9 +241,11 @@ public class PrivilegesInterceptor {
             // We check originalRequested (what the user explicitly specified) rather than allIndices
             // (the fully resolved set) to avoid false positives from broad queries like _cat/indices
             // where tenant indices are incidentally included in the resolution.
-            final boolean localAllMonitorRequest = request instanceof LocalAllIndicesRequest
-                && ((LocalAllIndicesRequest) request).isDerivedFromLocalAllIndices()
-                && (IndicesStatsAction.NAME.equals(action) || ClusterHealthAction.NAME.equals(action));
+            final boolean localAllMonitorRequest = LocalAllIndicesRequestHelper.isTrustedLocalAllMonitorRequest(
+                request,
+                action,
+                threadPool.getThreadContext()
+            );
             if (!requestedResolved.isLocalAll() && !localAllMonitorRequest) {
                 final Set<String> originalRequested = requestedResolved.getOriginalRequested();
 

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluator.java
@@ -279,8 +279,8 @@ public class SystemIndexAccessEvaluator {
         final User user
     ) {
         // Perform access check is system index permissions are enabled
-        boolean containsSystemIndex = requestContainsAnySystemIndices(requestedResolved);
-        boolean containsRegularIndex = requestContainsAnyRegularIndices(requestedResolved);
+        boolean containsSystemIndex = !requestedResolved.isLocalAll() && requestContainsAnySystemIndices(requestedResolved);
+        boolean containsRegularIndex = !requestedResolved.isLocalAll() && requestContainsAnyRegularIndices(requestedResolved);
         boolean serviceAccountUser = user.isServiceAccount();
 
         // Calculate plugin-related information once for reuse
@@ -305,7 +305,7 @@ public class SystemIndexAccessEvaluator {
                 }
                 return PrivilegesEvaluatorResponse.insufficient("").reason("Service account cannot access regular indices");
             }
-            boolean containsProtectedIndex = requestContainsAnyProtectedSystemIndices(requestedResolved);
+            boolean containsProtectedIndex = !requestedResolved.isLocalAll() && requestContainsAnyProtectedSystemIndices(requestedResolved);
             if (containsProtectedIndex) {
                 auditLog.logSecurityIndexAttempt(request, action, task);
                 if (log.isInfoEnabled()) {

--- a/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacerTest.java
+++ b/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacerTest.java
@@ -16,15 +16,19 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.metadata.IndexAbstraction;
+import org.opensearch.security.privileges.actionlevel.legacy.IndexResolverReplacer.Resolved;
 import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.security.util.MockIndexMetadataBuilder;
 
@@ -32,6 +36,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class IndexResolverReplacerTest {
 
@@ -39,6 +44,25 @@ public class IndexResolverReplacerTest {
     private static final String INDEX = "alias-scale-index";
     private static final String ALIAS_PREFIX = "alias-scale-";
     private static final SortedMap<String, IndexAbstraction> ALIAS_HEAVY_LOOKUP = createAliasHeavyLookup();
+
+    @Test
+    public void asLocalAllPreservesResolutionAndSetsLocalAllFlag() {
+        Resolved resolved = new Resolved(
+            ImmutableSet.of("alias"),
+            ImmutableSet.of("index"),
+            ImmutableSet.of("index"),
+            ImmutableSet.of(),
+            Map.of(),
+            IndicesOptions.STRICT_EXPAND_OPEN
+        );
+
+        Resolved localAll = resolved.asLocalAll();
+
+        assertThat(resolved.isLocalAll(), is(false));
+        assertThat(localAll.isLocalAll(), is(true));
+        assertThat(localAll.getAliases(), equalTo(resolved.getAliases()));
+        assertThat(localAll.getAllIndices(), equalTo(resolved.getAllIndices()));
+    }
 
     // ---------------------------------------------------------------------
     // Instrumentation tests: prove the bounded path does NOT scan the full


### PR DESCRIPTION
## Summary

Consume OpenSearch Core's all-indices provenance for index-stats and cluster-health requests handled by the legacy multi-tenancy authorization path.

Trusted marked monitor requests retain local-all authorization semantics even after a coordinating API resolves them to concrete indices. Direct requests for concrete tenant indices remain denied.

## Security properties

- A request must carry Core's marker and be proven local by Core's ThreadContext transient or arrive over authenticated node-to-node transport.
- A serialized marker alone is insufficient.
- The exception is restricted to index-stats and cluster-health actions.
- Direct concrete tenant-index stats and health requests remain forbidden.
- System/protected-index filtering is bypassed only for a resolution explicitly converted to trusted local-all semantics.

## Validation

- Legacy system-index list flow: `DashboardMultiTenancyIntTests` completed with 27 tests and 0 failures.
- Negative direct-concrete flow: `monitorActions_directlyTargetingConcreteTenantIndex_shouldBeDenied` passes.
- `spotlessApply`, `compileIntegrationTestJava`, and `IndexResolverReplacerTest.asLocalAllPreservesResolutionAndSetsLocalAllFlag` pass with `-Pcrypto.standard=FIPS-140-3`.

## Dependencies

- Core provenance: https://github.com/cwperks/OpenSearch/pull/379
- ML Commons caller: https://github.com/cwperks/ml-commons/pull/2
- This PR is intentionally stacked on the tactical fix branch (`agent/fix-tenant-monitor-requests`) so the broader follow-up remains isolated.