### PR TITLE
Filter tenant indices from broad monitor requests

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
@@ -33,6 +33,7 @@ import org.opensearch.test.framework.matcher.RestIndexMatchers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.cluster.TestRestClient.json;
 import static org.opensearch.test.framework.matcher.RestIndexMatchers.OnResponseIndexMatcher.containsExactly;
@@ -1017,6 +1018,45 @@ public class DashboardMultiTenancyIntTests {
             );
 
             assertThat(response, isOk());
+        }
+    }
+
+    /**
+     * Treats Dashboards tenant indices like hidden indices when they are incidentally included
+     * in otherwise broad stats and health requests.
+     */
+    @Test
+    public void broadMonitorRequests_shouldFilterConcreteTenantIndices() {
+        // Only run once (not for every parameterized user)
+        if (!user.equals(WILDCARD_TENANT_USER)) {
+            return;
+        }
+
+        String visibleIndex = "visible-monitor-index";
+        try (TestRestClient adminRestClient = cluster.getAdminCertRestClient()) {
+            assertThat(adminRestClient.putJson(visibleIndex, "{}"), isOk());
+        }
+
+        try (TestRestClient restClient = cluster.getRestClient(WILDCARD_TENANT_USER)) {
+            String indices = visibleIndex + "," + dashboards_index_human_resources.name();
+
+            TestRestClient.HttpResponse statsResponse = restClient.get(
+                indices + "/_stats",
+                new BasicHeader("securitytenant", "human_resources")
+            );
+            assertThat(statsResponse, isOk());
+            assertThat(statsResponse.getBody(), containsString(visibleIndex));
+            assertThat(statsResponse.getBody(), not(containsString(dashboards_index_human_resources.name())));
+
+            TestRestClient.HttpResponse healthResponse = restClient.get(
+                "_cluster/health/" + indices + "?level=indices",
+                new BasicHeader("securitytenant", "human_resources")
+            );
+            assertThat(healthResponse, isOk());
+            assertThat(healthResponse.getBody(), containsString(visibleIndex));
+            assertThat(healthResponse.getBody(), not(containsString(dashboards_index_human_resources.name())));
+        } finally {
+            delete(visibleIndex);
         }
     }
 

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
@@ -146,6 +146,13 @@ public class PrivilegesEvaluationContext {
         return result;
     }
 
+    /**
+     * Invalidates the cached resolution after the request's index expressions have been rewritten.
+     */
+    public void invalidateResolvedIndices() {
+        this.resolvedIndices = null;
+    }
+
     public Task getTask() {
         return task;
     }

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/DashboardsTenantIndicesRequestFilter.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/DashboardsTenantIndicesRequestFilter.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file to be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.privileges.actionlevel;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.admin.cluster.health.ClusterHealthAction;
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.opensearch.action.admin.indices.stats.IndicesStatsAction;
+import org.opensearch.action.admin.indices.stats.IndicesStatsRequest;
+import org.opensearch.security.privileges.DashboardsMultiTenancyConfiguration;
+import org.opensearch.security.user.User;
+
+/**
+ * A transitional compatibility shim that treats Dashboards tenant indices as hidden from broad
+ * monitor requests until they are created with {@code index.hidden=true}.
+ */
+public class DashboardsTenantIndicesRequestFilter {
+    private static final Logger log = LogManager.getLogger(DashboardsTenantIndicesRequestFilter.class);
+
+    private final Supplier<DashboardsMultiTenancyConfiguration> multiTenancyConfigurationSupplier;
+
+    public DashboardsTenantIndicesRequestFilter(Supplier<DashboardsMultiTenancyConfiguration> multiTenancyConfigurationSupplier) {
+        this.multiTenancyConfigurationSupplier = multiTenancyConfigurationSupplier;
+    }
+
+    /**
+     * Rewrites mixed stats and health requests to exclude concrete Dashboards tenant indices.
+     *
+     * @return true if the request was rewritten
+     */
+    public boolean filter(ActionRequest request, String action, User user, Collection<String> resolvedIndices) {
+        if (isApplicable(action, user) == false) {
+            return false;
+        }
+
+        DashboardsMultiTenancyConfiguration multiTenancyConfiguration = multiTenancyConfigurationSupplier.get();
+        String tenantIndexPrefix = multiTenancyConfiguration.dashboardsIndex() + "_";
+        Set<String> nonTenantIndices = new HashSet<>();
+        boolean containsTenantIndex = false;
+        for (String index : resolvedIndices) {
+            if (index.startsWith(tenantIndexPrefix)) {
+                containsTenantIndex = true;
+            } else {
+                nonTenantIndices.add(index);
+            }
+        }
+
+        // A tenant-only request may be explicit, so leave it on the existing authorization path.
+        if (containsTenantIndex == false || nonTenantIndices.isEmpty()) {
+            return false;
+        }
+
+        String[] filteredIndices = nonTenantIndices.toArray(String[]::new);
+        if (request instanceof IndicesStatsRequest indicesStatsRequest) {
+            indicesStatsRequest.indices(filteredIndices);
+        } else if (request instanceof ClusterHealthRequest clusterHealthRequest) {
+            clusterHealthRequest.indices(filteredIndices);
+        } else {
+            return false;
+        }
+
+        log.debug("Filtered Dashboards tenant indices from broad monitor request [{}]", action);
+        return true;
+    }
+
+    /**
+     * Returns whether this filter applies to the action and user.
+     */
+    public boolean isApplicable(String action, User user) {
+        if ((IndicesStatsAction.NAME.equals(action) || ClusterHealthAction.NAME.equals(action)) == false) {
+            return false;
+        }
+
+        DashboardsMultiTenancyConfiguration multiTenancyConfiguration = multiTenancyConfigurationSupplier.get();
+        if (multiTenancyConfiguration.multitenancyEnabled() == false
+            || user.getName().equals(multiTenancyConfiguration.dashboardsServerUsername())) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
@@ -92,6 +92,7 @@ import org.opensearch.security.privileges.PrivilegesEvaluationContext;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.privileges.PrivilegesEvaluatorResponse;
 import org.opensearch.security.privileges.RoleMapper;
+import org.opensearch.security.privileges.actionlevel.DashboardsTenantIndicesRequestFilter;
 import org.opensearch.security.privileges.actionlevel.RoleBasedActionPrivileges;
 import org.opensearch.security.privileges.actionlevel.RuntimeOptimizedActionPrivileges;
 import org.opensearch.security.privileges.actionlevel.SubjectBasedActionPrivileges;
@@ -131,6 +132,7 @@ public class PrivilegesEvaluatorImpl implements PrivilegesEvaluator {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     private final Supplier<ClusterState> clusterStateSupplier;
+    private final DashboardsTenantIndicesRequestFilter dashboardsTenantIndicesRequestFilter;
 
     private final IndexNameExpressionResolver resolver;
 
@@ -168,6 +170,9 @@ public class PrivilegesEvaluatorImpl implements PrivilegesEvaluator {
         this.threadContext = coreDependencies.threadContext();
         this.threadPool = coreDependencies.threadPool();
         this.clusterStateSupplier = coreDependencies.clusterStateSupplier();
+        this.dashboardsTenantIndicesRequestFilter = new DashboardsTenantIndicesRequestFilter(
+            dynamicDependencies.multiTenancyConfigurationSupplier()
+        );
         this.settings = coreDependencies.settings();
         this.indicesRequestResolver = new IndicesRequestResolver(coreDependencies.indexNameExpressionResolver());
 
@@ -360,7 +365,10 @@ public class PrivilegesEvaluatorImpl implements PrivilegesEvaluator {
             return presponse;
         }
 
-        final Resolved requestedResolved = this.irr.resolveRequest(request);
+        Resolved requestedResolved = this.irr.resolveRequest(request);
+        if (dashboardsTenantIndicesRequestFilter.filter(request, action0, user, requestedResolved.getAllIndices())) {
+            requestedResolved = this.irr.resolveRequest(request);
+        }
 
         log.debug("RequestedResolved : {}", requestedResolved);
 

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImpl.java
@@ -61,6 +61,7 @@ import org.opensearch.security.privileges.IndicesRequestResolver;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
 import org.opensearch.security.privileges.PrivilegesEvaluatorResponse;
 import org.opensearch.security.privileges.RoleMapper;
+import org.opensearch.security.privileges.actionlevel.DashboardsTenantIndicesRequestFilter;
 import org.opensearch.security.privileges.actionlevel.RoleBasedActionPrivileges;
 import org.opensearch.security.privileges.actionlevel.RuntimeOptimizedActionPrivileges;
 import org.opensearch.security.privileges.actionlevel.SubjectBasedActionPrivileges;
@@ -125,6 +126,7 @@ public class PrivilegesEvaluatorImpl implements org.opensearch.security.privileg
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final ThreadContext threadContext;
     private final DashboardsMultitenancySystemIndexHandler dashboardsMultitenancySystemIndexHandler;
+    private final DashboardsTenantIndicesRequestFilter dashboardsTenantIndicesRequestFilter;
     private final Settings settings;
     private final AtomicReference<RoleBasedActionPrivileges> actionPrivileges = new AtomicReference<>();
     private final ImmutableMap<String, ActionPrivileges> pluginIdToActionPrivileges;
@@ -144,6 +146,9 @@ public class PrivilegesEvaluatorImpl implements org.opensearch.security.privileg
         this.threadPool = coreDependencies.threadPool();
         this.clusterStateSupplier = coreDependencies.clusterStateSupplier();
         this.settings = coreDependencies.settings();
+        this.dashboardsTenantIndicesRequestFilter = new DashboardsTenantIndicesRequestFilter(
+            dynamicDependencies.multiTenancyConfigurationSupplier()
+        );
         this.specialIndexProtection = new RuntimeOptimizedActionPrivileges.SpecialIndexProtection(
             dynamicDependencies.specialIndices()::isUniversallyDeniedIndex,
             dynamicDependencies.specialIndices()::isSystemIndex,
@@ -249,6 +254,13 @@ public class PrivilegesEvaluatorImpl implements org.opensearch.security.privileg
         String action = this.actionConfiguration.normalize(context.getAction());
         User user = context.getUser();
         ActionRequest request = context.getRequest();
+        if (dashboardsTenantIndicesRequestFilter.isApplicable(action, user)) {
+            OptionallyResolvedIndices resolvedIndices = context.getResolvedIndices();
+            if (resolvedIndices instanceof ResolvedIndices resolved
+                && dashboardsTenantIndicesRequestFilter.filter(request, action, user, resolved.local().names(context.clusterState()))) {
+                context.invalidateResolvedIndices();
+            }
+        }
 
         if (request instanceof PitSegmentsRequest pitSegmentsRequest && isAllPitsRequest(pitSegmentsRequest)) {
             // We treat this as a separate cluster action. This is because there is no way to reduce the requested


### PR DESCRIPTION
## Summary

- add a transitional Security-side filter that treats configured Dashboards tenant backing indices like hidden indices in mixed monitor requests
- rewrite index stats and cluster health requests to contain only their non-tenant indices
- apply the same behavior to the legacy and v4 privilege evaluators, and re-resolve authorization after mutation
- add parameterized integration coverage for both APIs

## Motivation

This is a deliberately tactical compatibility shim toward creating Dashboards tenant indices with `index.hidden=true`. Broad monitoring requests should not expose tenant backing indices merely because those concrete indices were included alongside ordinary indices.

## Scope and limitations

- applies only while multi-tenancy is enabled
- applies only to index stats and cluster health
- bypasses the configured Dashboards server user
- rewrites the actual request, rather than only the authorization view
- leaves tenant-only requests on the existing authorization path because Security cannot distinguish an explicit direct request from a downstream child request containing only tenant indices without request provenance
- does not reproduce `expand_wildcards=all`; real hidden-index metadata remains the preferred long-term behavior

## Testing

```text
./gradlew spotlessApply compileIntegrationTestJava -Pcrypto.standard=FIPS-140-3
./gradlew :integrationTest --tests 'org.opensearch.security.privileges.int_tests.DashboardMultiTenancyIntTests' -Pcrypto.standard=FIPS-140-3
```

The integration matrix ran 486 tests with zero failures.